### PR TITLE
moodle-mergeusers - added control on table groups_members.

### DIFF
--- a/index.php
+++ b/index.php
@@ -174,6 +174,9 @@ if ($data) {
             continue;
             // go onto next table
         }
+        if($table_name == $CFG->prefix.'groups_members') {
+            mergeGroupMembers($newUser, $currentUser, $recordsToModify);
+        }
 
         $idString = implode(', ', $recordsToModify);
         $updateRecords = "UPDATE ".$table_name." SET ".$field_name." = '".$newUser."' WHERE ".PRIMARY_KEY." IN (".$idString.")";


### PR DESCRIPTION
This is the control over the table groups_members. 

It gives us several problems, and, for us, no solution was to skip it or to update it on all records.

In the documentation of the function mergeGroupMembers, you will find the explanation (actually, very similar to grade_grades).

Hope this helps. Looking for feedback too ;-)

Jordi
