### PR TITLE
Better handling of finding users to merge

### DIFF
--- a/index.php
+++ b/index.php
@@ -43,7 +43,7 @@ require_once('./index_form.php');
 require('./locallib.php');
 
 require_login();
-require_capability('moodle/site:config', get_context_instance(CONTEXT_SYSTEM));
+require_capability('moodle/site:config', context_system::instance());
 
 admin_externalpage_setup('toolmergeusers');
 
@@ -64,18 +64,17 @@ if ($data) {
     $transaction = $DB->start_delegated_transaction();
 
    // Get the userids
-   $user1 = $DB->get_record('user', array($data->oldusergroup['olduseridtype'] => $data->oldusergroup['olduserid']));
-   if (!$user1) {
-        print_error('errornouserid', 'tool_mergeusers');
-   }
+   $user1 = $DB->get_record('user', array($data->oldusergroup['olduseridtype'] => $data->oldusergroup['olduserid']), '*', MUST_EXIST);
    $currentUser = $user1->id;
    $currentUserName = $user1->username;
-   $user2 = $DB->get_record('user', array($data->newusergroup['newuseridtype'] => $data->newusergroup['newuserid']));
-   if (!$user2) {
-       print_error('errornouserid', 'tool_mergeusers');
-    }
+   $user2 = $DB->get_record('user', array($data->newusergroup['newuseridtype'] => $data->newusergroup['newuserid']), '*', MUST_EXIST);
     $newUser = $user2->id;
     $newUserName = $user2->username;
+
+    // Make sure we aren't trying to merge the same user.
+    if ($user1->id == $user2->id) {
+        print_error('errorsameuser', 'tool_mergeusers');
+    }
 
     echo('<h2>'.get_string('merging', 'tool_mergeusers').' &laquo;'.$currentUserName.'&raquo; (user ID = '.$currentUser.') '.get_string('into', 'tool_mergeusers').' &laquo;'.$newUserName.'&raquo; (user ID = '.$newUser.')</h2>');
 

--- a/index_form.php
+++ b/index_form.php
@@ -56,7 +56,7 @@ class mergeuserform extends moodleform {
         $olduser[] = $mform->createElement('text', 'olduserid', "", 'size="10"');
         $olduser[] = $mform->createElement('select', 'olduseridtype', '', $idstype, '');
         $mform->addGroup($olduser, 'oldusergroup', get_string('olduserid', 'tool_mergeusers'));
-        $mform->setType('olduserid', PARAM_INT);
+        $mform->setType('oldusergroup[olduserid]', PARAM_USERNAME);
         $mform->addGroupRule('oldusergroup', array(array(
             'olduserid' => array($strrequired, 'required', null, 'client'),
             'olduseridtype' => array($strrequired, 'required', null, 'client'),
@@ -67,7 +67,7 @@ class mergeuserform extends moodleform {
         $newuser[] = $mform->createElement('text', 'newuserid', "", 'size="10"');
         $newuser[] = $mform->createElement('select', 'newuseridtype', '', $idstype, '');
         $mform->addGroup($newuser, 'newusergroup', get_string('newuserid', 'tool_mergeusers'));
-        $mform->setType('newuserid', PARAM_INT);
+        $mform->setType('newusergroup[newuserid]', PARAM_USERNAME);
         $mform->addGroupRule('newusergroup', array(array(
             'newuserid' => array($strrequired, 'required', null, 'client'),
             'newuseridtype' => array($strrequired, 'required', null, 'client'),

--- a/lang/ca/tool_mergeusers.php
+++ b/lang/ca/tool_mergeusers.php
@@ -21,13 +21,12 @@ $string['description'] = '
     <p>Aquest procés usa funcions depenents de la base de dades i pot ser que el seu funcionament
     no estigui del tot comprovat per la vostra base de dades. <strong>Recorda que aquesta acció és
     irreversible!</strong></p>';
-$string['errornouserid'] = 'No s\'ha pogut obtenir l\'ID d\'usuari';
+$string['errorsameuser'] = 'Tractant de combinar el mateix usuari';
 $string['mergeusers'] = 'Fusiona comptes d\'usuari';
 $string['merging'] = 'Fusionant';
 $string['into'] = 'dins';
 $string['newuserid'] = 'ID d\'usuari a mantenir';
 $string['olduserid'] = 'ID d\'usuari a eliminar';
-$string['useridnotexist'] = 'L\'ID d\'usuari no existeix';
 $string['mergeusers:view'] = 'Fusió de comptes d\'usuari';
 $string['tableok'] = 'Taula {$a} : correctament actualitzada';
 $string['tableko'] = 'Taula {$a} : no s\'ha pogut actualitzar correctament!';

--- a/lang/en/tool_mergeusers.php
+++ b/lang/en/tool_mergeusers.php
@@ -17,13 +17,12 @@ $string['description'] = '
     <h1>Merge two users into a single account.</h1>
     <p>Given a user ID to be deleted and a user ID to keep, this will merge the user data associated with the former user ID into the latter user ID. Note that both user IDs must already exist and no accounts will actually be deleted. That process is left to the administrator to do manually.</p>
     <p>This process involves some database dependant functions and may not have been fully tested on your particular choice of database. <strong>Only do this if you know what you are doing as it is not reversable!</strong></p>';
-$string['errornouserid'] = 'Cannot retrieve user ID';
+$string['errorsameuser'] = 'Trying to merge the same user';
 $string['mergeusers'] = 'Merge user accounts';
 $string['merging'] = 'Merging';
 $string['into'] = 'into';
 $string['newuserid'] = 'User ID to be kept';
 $string['olduserid'] = 'User ID to be removed';
-$string['useridnotexist'] = 'User ID does not exist';
 $string['mergeusers:view'] = 'Merge User Accounts';
 $string['tableok'] = 'Table {$a} : update OK';
 $string['tableko'] = 'Table {$a} : update NOT OK!';

--- a/lang/es/tool_mergeusers.php
+++ b/lang/es/tool_mergeusers.php
@@ -21,13 +21,12 @@ $string['description'] = '
     <p>Este proceso usa funciones que dependen de la base de dadtos y puede ser que su funcionamiento
     no esté totalmente comprobado para vuestra base de datos. <strong>Recuerda que esta acción es
     irreversible!</strong></p>';
-$string['errornouserid'] = 'No se ha podido obtener el ID de usuario';
+$string['errorsameuser'] = 'Tratando de combinar el mismo usuario';
 $string['mergeusers'] = 'Fusiona cuentas de usuario';
 $string['merging'] = 'Fusionando';
 $string['into'] = 'dentro';
 $string['newuserid'] = 'ID de usuario a mantener';
 $string['olduserid'] = 'ID de usuario a eliminar';
-$string['useridnotexist'] = 'El ID de usuario no existe';
 $string['mergeusers:view'] = 'Fusión de cuentas de usuario';
 $string['tableok'] = 'Tabla {$a} : correctamente actualizada';
 $string['tableko'] = 'Tabla {$a} : no se ha podido actualizar correctamente!';

--- a/lang/fr/tool_mergeusers.php
+++ b/lang/fr/tool_mergeusers.php
@@ -17,13 +17,12 @@ $string['description'] = '
     <h1>Fusionner deux comptes utilisateur en un.</h1>
     <p>Etant donné un ID utilisateur à supprimer et un ID utilisateur à conserver, ceci fusionnera toutes les données utilisateur vers le compte de l\'utilisateur à conserver. Les deux ID utilisateur doivent exister dans la base d\'utilisateurs de Moodle, et aucun compte n\'est supprimé par cet utilitaire (ceci est laissé au loisir de l\'administrateur).</p>
     <p>Ce procédé utilise certaines fonctions variant d\'un système de bases de données à l\'autre, et peut ne pas avoir été testé correctement pour votre type de base de données. <strong>N\'utilisez ceci que si vous en comprenez les implications, car les opérations réalisées ici ne sont pas réversibles !</strong></p>';
-$string['errornouserid'] = 'Impossible de trouver l\'ID utilisateur';
+$string['errorsameuser'] = 'Essayer de fusionner le même utilisateur';
 $string['mergeusers'] = 'Fusionner des comptes utilisateur';
 $string['merging'] = 'Fusion';
 $string['into'] = 'vers';
 $string['newuserid'] = 'ID utilisateur à conserver';
 $string['olduserid'] = 'ID utilisateur à supprimer';
-$string['useridnotexist'] = 'L\'ID utilisateur n\'existe pas';
 $string['mergeusers:view'] = 'Fusionner les comptes utilisateur';
 $string['tableok'] = 'Table {$a} : mise à jour OK';
 $string['tableko'] = 'Table {$a} : mise à jour PAS OK!';


### PR DESCRIPTION
- When searching on idnumber, multiple user records can be returned. So using MUST_EXIST parameter for Moodle database API. This also ensures that a user record exists. Removed now unnecessary error handling and related strings.
- Handling if trying to merge the same user accounts.
- Fixed debugging messages that appear in Moodle 2.5, because setType wasn't being called on the correct form field. Also, changed type from PARAM_INT to PARAM_USERNAME.
- Replaced now deprecated call to get system context.
- Updated lang strings for new error string and removed error strings no longer referenced.
