### PR TITLE
moodle-tool_mergeusers - several improvements:

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -59,6 +59,7 @@ You can go further and develop your own CLI script by extending the Gathering in
 (see lib/cligathering.php for an example). Ok, but let us explain how to do it step by step:
 
 1. Develop a class, namely MyGathering, in lib/mygathering.php, implementing the interface Gathering.
+Be sure the class name and the filename are the same, but filename all in lowercase ending with ".php".
 See lib/cligathering for an example.
 2. Create or edit the file config/config.local.php with at least the following content:
 ```php
@@ -70,11 +71,7 @@ return array(
     'gathering' => 'MyGathering',
 );
 ```
-3. Add your file to the library, appending a line in lib/lib.php like this:
-```php
-require_once __DIR__ . '/mygathering.php';
-```
-4. Run as a command line in a form like this: *$ time php cli/climerger.php*.
+3. Run as a command line in a form like this: *$ time php cli/climerger.php*.
 
 
 Correct way of testing this plugin

--- a/cli/climerger.php
+++ b/cli/climerger.php
@@ -32,7 +32,7 @@ ini_set('error_reporting', E_ALL | E_STRICT);
 global $CFG;
 
 require_once $CFG->dirroot . '/lib/clilib.php';
-require_once __DIR__ . '/../lib/lib.php';
+require_once __DIR__ . '/../lib/autoload.php';
 
 // loads current configuration
 $config = Config::instance();

--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ require_once($CFG->libdir.'/accesslib.php');
 require_once($CFG->libdir.'/weblib.php');
 
 require_once('./index_form.php');
-require_once('./locallib.php');
+require_once(__DIR__ . '/lib/autoload.php');
 
 require_login();
 require_capability('moodle/site:config', context_system::instance());

--- a/lib/autoload.php
+++ b/lib/autoload.php
@@ -22,10 +22,16 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined("MOODLE_INTERNAL") || die();
+spl_autoload_register(function ($class) {
 
-require_once __DIR__ . '/config.php';
-require_once __DIR__ . '/merger.php';
-require_once __DIR__ . '/logger.php';
-require_once __DIR__ . '/gathering.php';
-require_once __DIR__ . '/cligathering.php';
+    $fileName = strtolower($class) . '.php';
+    $fileDirname = dirname(__FILE__);
+
+    if(is_file($fileDirname.'/'.$fileName)) {
+        require_once $fileDirname.'/'.$fileName;
+        if(class_exists($class)) {
+            return true;
+        }
+    }
+    return false;
+});

--- a/lib/cligathering.php
+++ b/lib/cligathering.php
@@ -54,18 +54,6 @@ class CLIGathering implements Gathering {
     {
         $this->index = -1;
         $this->end = false;
-        // to catch Ctrl+C interruptions, we need this stuff.
-        declare(ticks = 1);
-        pcntl_signal(SIGINT, array($this, 'aborting'));
-    }
-
-    /**
-     * Called when aborting from command-line on Ctrl+C interruption.
-     * @param int $signo only SIGINT.
-     */
-    public function aborting($signo) {
-        echo "\n\n" . get_string('ok') . ", exit!\n\n";
-        exit(0); //quiting normally after all ;-)
     }
 
     /**

--- a/lib/merger.php
+++ b/lib/merger.php
@@ -22,8 +22,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once __DIR__ . '/../locallib.php';
-require_once __DIR__ . '/lib.php';
+require_once __DIR__ . '/autoload.php';
 
 class Merger {
     /**
@@ -38,6 +37,21 @@ class Merger {
     public function __construct(MergeUserTool $mut) {
         $this->mut = $mut;
         $this->logger = new Logger();
+
+        // to catch Ctrl+C interruptions, we need this stuff.
+        declare(ticks = 1);
+        pcntl_signal(SIGINT, array($this, 'aborting'));
+    }
+
+    /**
+     * Called when aborting from command-line on Ctrl+C interruption.
+     * @param int $signo only SIGINT.
+     */
+    public function aborting($signo) {
+        if (defined("CLI_SCRIPT")) {
+            echo "\n\n" . get_string('ok') . ", exit!\n\n";
+        }
+        exit(0); //quiting normally after all ;-)
     }
 
     /**

--- a/log.php
+++ b/log.php
@@ -32,7 +32,7 @@ error_reporting(E_ALL);
 ini_set('display_errors', 'On');
 
 require_once($CFG->dirroot . '/lib/adminlib.php');
-require_once('lib/lib.php');
+require_once('lib/autoload.php');
 
 require_login();
 require_capability('moodle/site:config', context_system::instance());

--- a/version.php
+++ b/version.php
@@ -29,8 +29,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2013120514;
+$plugin->version   = 2013121115;
 $plugin->requires  = 2011120500;
 $plugin->component = 'tool_mergeusers';
 $plugin->maturity = MATURITY_BETA;
-$plugin->release = '1.5 (Build: 2013120514)';
+$plugin->release = '1.5 (Build: 2013121115)';

--- a/view.php
+++ b/view.php
@@ -32,7 +32,7 @@ error_reporting(E_ALL);
 ini_set('display_errors', 'On');
 
 require_once($CFG->dirroot . '/lib/adminlib.php');
-require_once('lib/lib.php');
+require_once('lib/autoload.php');
 
 require_login();
 require_capability('moodle/site:config', context_system::instance());


### PR DESCRIPTION
```
* lib/autoload.php to enable autoloading of classes from the plugin. Removed lib/lib.php
* moved locallib.php to lib/mergeusertool.php to enable autoloading.
* updated README.txt for new Gatherings.
* Ctrl+C is moved from Gathering to Merger class, to remove this responsibility from new Gathering implementations.
* Detection of an incompatibility on special case on user_enrolments table: if a user A is merged into user B, but afterwards, user B has to be merged back into A, a conflict appears when processing the status == 2. It is weird, but it happaned to us. It now checks the status flag to know whether to update record to status = 0 (to reactivate a deactivated record), and status = 2 (to deactivate an activated record). See the lib/mergeusertool.php.
```
