### PR TITLE
moodle-tool_mergeusers - two improvements

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -24,7 +24,7 @@ cases:
     together I recomend disabling or deleting the entire old user account once
     the migration has been successful.
 * Special Case #3: There are 3 logging/preference tables
-    (user_lastaccess, user_preferences,user_private_key) which exist in
+    (user_lastaccess, user_preferences, user_private_key) which exist in
     Moodle 2.0. This script is simply skipping these tables since there's no
     legitimate purpose to updating the userid value here. This would lead to
     duplicate rows for the new user which is silly. Again, if you want to
@@ -47,6 +47,10 @@ cases:
     so we can securely remove the old record. In addition, this checking is performed
     for both column names (userid and contactid) looking for matching on both
     in the same way.
+* Special case #8: role_assignments table has a three-field unique index,
+    including context, role and userid. As before, it always updates records to
+    be the new one. If only old id exists, it is updated; if only new id exists,
+    it does nothing; if both ids exist, the record with the old id is removed.
 
 
 Command-line script

--- a/config/config.php
+++ b/config/config.php
@@ -49,29 +49,34 @@ return array(
     // List of compound indexes.
     // This list may vary from Moodle instance to another, given that the Moodle version,
     // local changes and non-core plugins may add new special cases to be processed.
+    // When 'both' field is set, this means that user.id values may appear in the list of 'otherfields' too.
     // See README.txt for details on special cases.
     // Table names must be without $CFG->prefix.
     'compoundindexes' => array(
         'grade_grades' => array(
             'userfield' => 'userid',
-            'otherfield' => 'itemid',
+            'otherfields' => array('itemid'),
         ),
         'groups_members' => array(
             'userfield' => 'userid',
-            'otherfield' => 'groupid',
+            'otherfields' => array('groupid'),
         ),
         'journal_entries' => array(
             'userfield' => 'userid',
-            'otherfield' => 'journal',
+            'otherfields' => array('journal'),
         ),
         'course_completions' => array(
             'userfield' => 'userid',
-            'otherfield' => 'course',
+            'otherfields' => array('course'),
         ),
         'message_contacts' => array(//both fields are user.id values
             'userfield' => 'userid',
-            'otherfield' => 'contactid',
+            'otherfields' => array('contactid'),
             'both' => true,
+        ),
+        'role_assignments' => array(
+            'userfield' => 'userid',
+            'otherfields' => array('contextid', 'roleid'),
         ),
     ),
 


### PR DESCRIPTION
```
* This tool now supports keys of more than 2 terms on the key/index. To do so:
   * the config field 'otherfield' (string) becomes 'otherfields' (array(string1, string2,...)).
   * when field 'both' appears indicates a field on 'otherfields' may appear also as user-related field.
* A new compound index is included on the table role_assigments (compound index formed by userid, context and role).
```
