### PR TITLE
moodle-tool_mergeusers - #30 : description box as help icon

### DIFF
--- a/index_form.php
+++ b/index_form.php
@@ -52,7 +52,7 @@ class mergeuserform extends moodleform {
         );
 
         $mform->addElement('header', 'mergeusers', get_string('header', 'tool_mergeusers'));
-        $mform->addElement('html', get_string('description', 'tool_mergeusers'));
+        $mform->addHelpButton('mergeusers', 'header', 'tool_mergeusers');
 
         // Add elements
         $olduser = array();

--- a/lang/ca/tool_mergeusers.php
+++ b/lang/ca/tool_mergeusers.php
@@ -10,14 +10,14 @@
 
 $string['pluginname'] = 'Fusió de comptes d\'usuari';
 $string['header'] = 'Fusió de dos comptes d\'usuari en un de sol';
-$string['description'] =
- '<p>Donat un ID d\'usuari a ser eliminat i un ID a mantenir, aquesta eina fusiona/mou
- les dades relatives de l\'usuari a ser eliminat sobre l\'ID d\'usuari a mantenir.
- És important saber que tots dos IDs existeixin prèviament, i que cap compte s\'eliminarà
+$string['header_help'] =
+ '<p>Donat un usuari a ser eliminat i un usuari a mantenir, aquesta eina fusiona/mou
+ les dades relatives de l\'usuari a ser eliminat sobre l\'usuari a mantenir.
+ És important saber que tots dos usuaris existeixin prèviament, i que cap compte s\'eliminarà
  de Moodle. És tasca de l\'administrador de sistema d\'eliminar-lo manualment si s\'escau.</p>
  <p>Aquest procés usa funcions depenents de la base de dades i pot ser que el seu funcionament
- no estigui del tot comprovat per la vostra base de dades. <strong>Recorda que aquesta acció és
- irreversible!</strong></p>';
+ no estigui del tot comprovat per la vostra base de dades.</p>
+ <p><strong>Recorda que aquesta acció és irreversible!</strong></p>';
 $string['usermergingheader'] = '&laquo;{$a->username}&raquo; (user ID = {$a->id})';
 $string['errorsameuser'] = 'Tractant de combinar el mateix usuari';
 $string['mergeusers'] = 'Fusiona comptes d\'usuari';

--- a/lang/en/tool_mergeusers.php
+++ b/lang/en/tool_mergeusers.php
@@ -13,14 +13,14 @@
 
 $string['pluginname'] = 'Merge user accounts';
 $string['header'] = 'Merge two users into a single account';
-$string['description'] =
-'<p>Given a user ID to be deleted and a user ID to keep, this will merge the user data
- associated with the former user ID into the latter user ID. Note that both user IDs must
+$string['header_help'] =
+'<p>Given a user to be deleted and a user to keep, this will merge the user data
+ associated with the former user into the latter user. Note that both users must
  already exist and no accounts will actually be deleted. That process is left to the
  administrator to do manually.</p>
  <p>This process involves some database dependant functions and may not have been fully tested
- on your particular choice of database. <strong>Only do this if you know what you are doing
- as it is not reversable!</strong></p>';
+ on your particular choice of database.</p>
+ <p><strong>Only do this if you know what you are doing as it is not reversable!</strong></p>';
 $string['usermergingheader'] = '&laquo;{$a->username}&raquo; (user ID = {$a->id})';
 $string['errorsameuser'] = 'Trying to merge the same user';
 $string['mergeusers'] = 'Merge user accounts';

--- a/lang/es/tool_mergeusers.php
+++ b/lang/es/tool_mergeusers.php
@@ -10,14 +10,14 @@
 
 $string['pluginname'] = 'Fusión de cuentas de usuario';
 $string['header'] = 'Fusión de dos cuentas de usuario en una';
-$string['description'] =
-'<p>Dado un ID de usuario a ser eliminado y un ID a mantener, esta herramienta fusiona/mueve
- los datos relativos del usario a ser eliminado sobre el ID de usuario a manetener.
- Es importante saber que ambos IDs deben existir previamente, y que no se eliminará ninguna cuenta
+$string['header_help'] =
+'<p>Dado un usuario a ser eliminado y un usuario a mantener, esta herramienta fusiona/mueve
+ los datos relativos del usario a ser eliminado sobre el usuario a manetener.
+ Es importante saber que ambos usuarios deben existir previamente, y que no se eliminará ninguna cuenta
  de Moodle. El administrador de sistema deberá eliminarlo manualmente si es necesario.</p>
- <p>Este proceso usa funciones que dependen de la base de dadtos y puede ser que su funcionamiento
- no esté totalmente comprobado para vuestra base de datos. <strong>Recuerda que esta acción es
- irreversible!</strong></p>';
+ <p>Este proceso usa funciones que dependen de la base de datos y puede ser que su funcionamiento
+ no esté totalmente comprobado para vuestra base de datos.</p>
+ <p><strong>Recuerda que esta acción es irreversible!</strong></p>';
 $string['usermergingheader'] = '&laquo;{$a->username}&raquo; (user ID = {$a->id})';
 $string['errorsameuser'] = 'Tratando de combinar el mismo usuario';
 $string['mergeusers'] = 'Fusiona cuentas de usuario';

--- a/lang/fr/tool_mergeusers.php
+++ b/lang/fr/tool_mergeusers.php
@@ -13,14 +13,14 @@
 
 $string['pluginname'] = 'Fusionner des comptes utilisateur';
 $string['header'] = 'Fusionner deux comptes utilisateur en un';
-$string['description'] =
-'<p>Etant donné un ID utilisateur à supprimer et un ID utilisateur à conserver, ceci fusionnera
- toutes les données utilisateur vers le compte de l\'utilisateur à conserver. Les deux ID utilisateur
+$string['header_help'] =
+'<p>Etant donné un utilisateur à supprimer et un utilisateur à conserver, ceci fusionnera
+ toutes les données utilisateur vers le compte de l\'utilisateur à conserver. Les deux utilisateur
  doivent exister dans la base d\'utilisateurs de Moodle, et aucun compte n\'est supprimé par cet utilitaire
  (ceci est laissé au loisir de l\'administrateur).</p>
  <p>Ce procédé utilise certaines fonctions variant d\'un système de bases de données à l\'autre,
- et peut ne pas avoir été testé correctement pour votre type de base de données. <strong>N\'utilisez
- ceci que si vous en comprenez les implications, car les opérations réalisées ici ne sont pas
+ et peut ne pas avoir été testé correctement pour votre type de base de données. </p>
+ <p><strong>N\'utilisez ceci que si vous en comprenez les implications, car les opérations réalisées ici ne sont pas
  réversibles !</strong></p>';
 $string['usermergingheader'] = '&laquo;{$a->username}&raquo; (user ID = {$a->id})';
 $string['errorsameuser'] = 'Essayer de fusionner le même utilisateur';


### PR DESCRIPTION
Related to issue #30:
- moved the description box as help icon to build a simpler interface.
- updated text to remove the reference to 'ID' and replace them for 'user' references.
