### PR TITLE
moodle-tool_mergeusers - #37: moving button help from form to page header

### DIFF
--- a/index_form.php
+++ b/index_form.php
@@ -52,7 +52,6 @@ class mergeuserform extends moodleform {
         );
 
         $mform->addElement('header', 'mergeusers', get_string('header', 'tool_mergeusers'));
-        $mform->addHelpButton('mergeusers', 'header', 'tool_mergeusers');
 
         // Add elements
         $olduser = array();

--- a/renderer.php
+++ b/renderer.php
@@ -40,7 +40,7 @@ class tool_mergeusers_renderer extends plugin_renderer_base
     public function index_page(moodleform $mform)
     {
         $output = $this->header();
-        $output .= $this->heading(get_string('mergeusers', 'tool_mergeusers'));
+        $output .= $this->heading_with_help(get_string('mergeusers', 'tool_mergeusers'), 'header', 'tool_mergeusers');
         $output .= $this->moodleform($mform);
         $output .= $this->footer();
         return $output;


### PR DESCRIPTION
Related to issue #37:
- A better place for the button help, considering John contributions,
  I think it is better to place it in the header instead of the form.
