### PR TITLE
moodle-tool_mergeusers - #29 - supporting merging only if transactions are allowed.

### DIFF
--- a/lang/ca/tool_mergeusers.php
+++ b/lang/ca/tool_mergeusers.php
@@ -37,7 +37,7 @@ $string['dbko'] = 'Fusió fallida! <br/>Si la teva base de dades suporta transac
 $string['tableskipped'] = 'Per guardar registres i seguretat, no processem la taula <strong>{$a}</strong>.
  <br />Per eliminar aquestes entrades, elimina el compte d\'usuari antic una vegada aquesta acció
  hagi finalitzat correctament.';
-$string['errordatabase'] = 'Error en la base de datos de tipo {$a}';
+$string['errordatabase'] = 'Error: tipus de base de dades {$a} no suportada.';
 $string['invaliduser'] = 'Usuari invàlid';
 $string['cligathering:description'] = "Introdueix parells d'identificadors d'usuari per fusionar el primer sobre el segon.
 El primer (fromid) perdrà totes les seves dades i es passaran al segon (toid) que inclourà les dades d'ambdós.";
@@ -51,3 +51,26 @@ $string['olduseridonlog'] = 'ID d\'usuari eliminat';
 $string['nologs'] = 'No hi ha registres de fusions d\'usuari. Bé per tu!';
 $string['wronglogid'] = 'No existeix el registre que estàs demanant.';
 $string['deleted'] = 'Usuari {$a} eliminat';
+$string['errortransactionsonly'] = 'Error: es requereixen transaccions, i la seva base de dades {$a} no les suporta.
+    Si ho necessita, pot configurar que les fusions es realitzin sense transaccions.
+    Revisi la configuració perquè s\'ajusti a les seves necessitats.';
+
+// Settings page
+$string['transactions_setting'] = 'Només transaccions';
+$string['transactions_setting_desc'] = 'Si s\'activa, la fusió d\'usuaris no
+    es realitzarà si la base de dades NO suporta transaccions (recomanat).
+    Amb aquesta opció activa, t\'assegures que la base de dades romandrà
+    sempre consistent, tot i que la fusió es conclogui amb errors. <br />
+    Si es desactiva, sempre realitzaràs la fusió d\'usuaris.
+    En cas d\'errors, el registre de la fusió et mostrarà quin és el problema.
+    Si notifiques d\'aquest error als desenvolupadors d\'aquest plugin,
+    tindràs la solució en breu.<br />
+    Tingues en compte que aquest plugin gestiona correctament totes les
+    taules de la base de dades de Moodle, i també d\'algun plugin de
+    terceres parts. Per tant, si només tens una instal·lació Moodle estàndar,
+    pots executar aquest plugin tranquilament tant amb aquesta opció activada
+    com desactivada.';
+$string['transactions_supported'] = 'Per la seva informació, la seva base
+    de dades <strong>suporta transaccions</strong>.';
+$string['transactions_not_supported'] = 'Per la seva informació, la seva base
+    de dades <strong>no suporta transaccions</strong>.';

--- a/lang/en/tool_mergeusers.php
+++ b/lang/en/tool_mergeusers.php
@@ -6,6 +6,7 @@
  * @author Juan Pablo Torres Herrera
  * @author Shane Elliott, Pukunui Technology
  * @author Jordi Pujol-Ahulló, SREd, Universitat Rovira i Virgili
+ * @author John Hoopes <hoopes@wisc.edu>, University of Wisconsin - Madison
  * @package tool_mergeusers
  * @link http://moodle.org/mod/forum/discuss.php?d=103425
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
@@ -40,7 +41,7 @@ $string['dbko'] = 'Merge FAILED! <br/>If your database engine supports
  made to your database records.';
 $string['tableskipped'] = 'For logging or security reasons we are skipping <strong>{$a}</strong>.
  <br />To remove these entries, delete the old user once this script has run successfully.';
-$string['errordatabase'] = 'Database type not supported: {$a}';
+$string['errordatabase'] = 'Error: Database type {$a} not supported.';
 $string['invaliduser'] = 'Invalid user';
 $string['cligathering:description'] = "Introduce pairs of user's id to merge the first one into the\n
 second one. The first user id (fromid) will 'lose' all its data to be 'migrated'\n
@@ -55,3 +56,23 @@ $string['olduseridonlog'] = 'User ID removed';
 $string['nologs'] = 'There is no merging logs yet. Good for you!';
 $string['wronglogid'] = 'The log you are asking for does not exist.';
 $string['deleted'] = 'User with ID {$a} was deleted';
+$string['errortransactionsonly'] = 'Error: transactions are required, but your database type {$a}
+    does not support them. If needed, you can allow merging users without transactions.
+    Please, review plugin settings to set up them accordingly.';
+
+// Settings page
+$string['transactions_setting'] = 'Only transactions allowed';
+$string['transactions_setting_desc'] = 'If enabled, merge users will not work
+    at all on databases that do NOT support transactions (recommended).
+    Enabling it is necessary to ensure that your database remains consistent
+    in case of merging errors. <br />If disabled, you will always run merging actions.
+    In case of errors, the merging log will show you what was the problem.
+    Reporting it to the plugin supporters will give you a solution in short.
+    <br />Above all, core Moodle tables and some third party plugins are already
+    considered by this plugin. If you do not have any third party plugins
+    in your Moodle installation, you can be quiet on running this plugin
+    enabling or disabling this option.';
+$string['transactions_supported'] = 'For your information, your database
+    <strong>supports transactions</strong>.';
+$string['transactions_not_supported'] = 'For your information, your database
+    <strong>does not supports transactions</strong>.';

--- a/lang/es/tool_mergeusers.php
+++ b/lang/es/tool_mergeusers.php
@@ -37,7 +37,7 @@ $string['dbko'] = 'Error en la fusión! <br/>Si vuestra base de datos soporta tr
 $string['tableskipped'] = 'Para guardar registros y por seguredad, no procesamos la tabla <strong>{$a}</strong>.
  <br />Para eliminar dichos registros, elimina la cuenta de usuario antigua una vez esta acción
  haya finalizado correctamente.';
-$string['errordatabase'] = 'Error en la base de dades de tipus {$a}';
+$string['errordatabase'] = 'Error: tipo de base de datos {$a} no soportada.';
 $string['invaliduser'] = 'Usuario inválido';
 $string['cligathering:description'] = "Introduce pares de identificadores de usuario para fusionar el primero sobre el segundo.\n
 El primero (fromid) perderá todos sus datos y se pasaran al segundo (toid) que incorporará los datos de ambos.";
@@ -51,3 +51,26 @@ $string['olduseridonlog'] = 'ID de usuario eliminado';
 $string['nologs'] = 'No hay registros de fusión de usuarios. Bien por ti!';
 $string['wronglogid'] = 'No existe el registro que estás solicitando.';
 $string['deleted'] = 'Usuario {$a} eliminado';
+$string['errortransactionsonly'] = 'Error: se requiren transacciones, y su base de datos {$a} no las soporta.
+    Si lo necesita, puede configurar que las fusiones se hagan sin transacciones.
+    Revise la configuración para que se ajuste a sus necesidades.';
+
+// Settings page
+$string['transactions_setting'] = 'Sólo transacciones';
+$string['transactions_setting_desc'] = 'Si se activa, la fusión de usuarios no
+    se realizará si la base de datos NO soporta transacciones (recomendado).
+    Con esta opción activa, te aseguras que la base de datos permanecerá
+    siempre consistente, incluso si la fusión termina con errores.<br />
+    Si se desactiva, siempre realizarás la fusión de usuarios.
+    En caso de errores, el registro de la fusión te mostrará cuál fue el problema.
+    Si informas de este error a los desarrolladores de este plugin,
+    tendrás la solución en breve.<br />
+    Ten en cuenta que este plugin gestiona correctamente todas las
+    tablas de la base de datos de Moodle, y también de algun plugin de
+    terceras partes. Por tanto, si sólo tienes una instalación Moodle estándard,
+    puedes ejecutar este plugin tranquilamente tanto con esta opción activada
+    com desactivada.';
+$string['transactions_supported'] = 'Para su información, su base
+    de datos <strong>soporta transacciones</strong>.';
+$string['transactions_not_supported'] = 'Para su información, su base
+    de datos <strong>no soporta transacciones</strong>.';

--- a/lang/fr/tool_mergeusers.php
+++ b/lang/fr/tool_mergeusers.php
@@ -42,7 +42,7 @@ $string['dbko'] = 'La fusion a ECHOUE !<br/>Si votre moteur de base de
 $string['tableskipped'] = 'Pour des raisons de traçabilité ou de sécurité, la table
  <strong>{$a}</strong> n\'est pas traitée.<br />Pour supprimer ces entrées, supprimez l\'ancien
  compte utilisateur une fois la fusion réussie.';
-$string['errordatabase'] = 'Type de base de données non supporté : {$a}';
+$string['errordatabase'] = 'Erreur: Type de base de données {$a} non supporté.';
 $string['invaliduser'] = 'Utilisateur non valide';
 $string['cligathering:description'] = 'Entrez les ID utilisateur à fusionner : le premier (fromid) vers le second (toid).
 Les données liées au premier utilisateur seront transférées vers le second, qui intégrera alors toutes les données.';
@@ -56,4 +56,27 @@ $string['olduseridonlog'] = 'ID d\'utilisateur supprimé';
 $string['nologs'] = 'Pas de records de fusion d\'utilisateurs. Bon pour vous!';
 $string['wronglogid'] = 'Il n\'existe aucun enregistrement correspondant à votre choix.';
 $string['deleted'] = 'L\'utilisateur ID {$a} a été éliminé';
+$string['errortransactionsonly'] = 'Erreur: Exiger des transactions, et votre
+    base de données {$a} ne les supporte pas. Si nécessaire, vous pouvez
+    configurer que les fusions sont faites sans transactions.
+    Vérifiez les paramètres en fonction de vos besoins.';
 
+// Settings page
+$string['transactions_setting'] = 'Seules les transactions sont autorisées';
+$string['transactions_setting_desc'] = 'Si cette option est activée,
+    les utilisateurs fusion effectuée si la base de données prend en charge
+    les transactions PAS (recommandé).
+    Avec cette option activée, vous vous assurez que la base de données reste
+    toujours cohérente, même si la fusion se termine avec des erreurs. <br />
+    Si cette option est désactivée, vous aurez toujours réaliser la fusion des
+    utilisateurs. En cas d\'erreur, l\'inscription de la fusion montrera quel
+    était le problème. Si vous signalé cette erreur aux développeurs de ce
+    plugin, avoir la solution bientôt. <br />
+    Notez que ce plugin bien géré tout les tables de la base de données de
+    Moodle, et aussi des plugins tiers. Par conséquent, si vous avez juste
+    une installation de Moodle standard, vous pouvez exécuter ce plugin si
+    calmement avec cette option activée com désactivé.';
+$string['transactions_supported'] = 'Pour votre information, sur la base
+    données <strong>prend en charge les transactions</strong>.';
+$string['transactions_not_supported'] = 'Pour votre information, sur la base
+    données <strong>ne prennent pas en charge les transactions</strong>.';

--- a/settings.php
+++ b/settings.php
@@ -23,10 +23,14 @@
  * @author     Mike Holzer
  * @author     Forrest Gaston
  * @author     Juan Pablo Torres Herrera
+ * @author     John Hoopes <hoopes@wisc.edu>, University of Wisconsin - Madison
+ * @author     Jordi Pujol-Ahulló, SREd, Universitat Rovira i Virgili
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die;
+
+require_once __DIR__ . '/lib/autoload.php';
 
 if ($hassiteconfig) {
     $ADMIN->add('accounts',
@@ -40,3 +44,18 @@ if ($hassiteconfig) {
             $CFG->wwwroot.'/'.$CFG->admin.'/tool/mergeusers/view.php',
             'moodle/site:config'));
 }
+
+// Add configuration for making user suspension optional
+$settings = new admin_settingpage('mergeusers_settings',
+    get_string('pluginname', 'tool_mergeusers'));
+
+$supporting_lang = (MergeUserTool::transactionsSupported()) ? 'transactions_supported' : 'transactions_not_supported';
+
+$settings->add(new admin_setting_configcheckbox('tool_mergeusers/transactions_only',
+    get_string('transactions_setting', 'tool_mergeusers'),
+    get_string('transactions_setting_desc', 'tool_mergeusers') . '<br /><br />' .
+        get_string($supporting_lang, 'tool_mergeusers'),
+    1));
+
+// Add settings
+$ADMIN->add('tools', $settings);

--- a/version.php
+++ b/version.php
@@ -24,13 +24,14 @@
  * @author     Forrest Gaston
  * @author     Juan Pablo Torres Herrera
  * @author     Jordi Pujol-Ahulló, SREd, Universitat Rovira i Virgili
+ * @author     John Hoopes <hoopes@wisc.edu>, University of Wisconsin - Madison
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2014011012;
+$plugin->version   = 2014042919;
 $plugin->requires  = 2011120500;
 $plugin->component = 'tool_mergeusers';
 $plugin->maturity = MATURITY_BETA;
-$plugin->release = '1.6 (Build: 2014011012)';
+$plugin->release = '1.7 (Build: 2014042919)';


### PR DESCRIPTION
Related to issue #29:
- Added setting to prevent from merging users if database does not support
  transactions.
- Added tricky way on MergeUserTool to get whether transactions are supported
  on curretn $DB object. See code for comments.
