### PR TITLE
tool_mergeusers: Simplify and correct getCurrentUserFieldNames()

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -101,7 +101,7 @@ return array(
         'message' => array('useridfrom', 'useridto'),
         'message_read' => array('useridfrom', 'useridto'),
         'question' => array('createdby', 'modifiedby'),
-        'default' => array('userid', 'user_id', 'id_user', 'user'), //may appear compound index
+        'default' => array('authorid', 'reviewerid', 'userid', 'user_id', 'id_user', 'user'), //may appear compound index
     ),
 
     // TableMergers to process each database table.


### PR DESCRIPTION
This commit takes care of the errors thrown on tables such as mdl_message_contacts by simplifying the getCurrentUserFieldNames() function from 49 lines to 2 lines. It now uses the time-tested Moodle database get_fieldset_sql() rather than reimplementing it incorrectly.
