### PR TITLE
Improve performance and move generic classes.

### DIFF
--- a/classes/config.php
+++ b/classes/config.php
@@ -51,9 +51,9 @@
  * If the key 'both' appears, means that both columns are user-related and must be searched for
  * both. See the README.txt for more details on special cases.
  */
-class Config {
+class tool_mergeusers_config {
     /**
-     * @var Config singleton instance.
+     * @var tool_mergeusers_config singleton instance.
      */
     private static $instance = null;
 
@@ -77,11 +77,11 @@ class Config {
 
     /**
      * Singleton method.
-     * @return Config singleton instance.
+     * @return tool_mergeusers_config singleton instance.
      */
     public static function instance() {
         if (is_null(self::$instance)) {
-            self::$instance = new Config();
+            self::$instance = new tool_mergeusers_config();
         }
         return self::$instance;
     }

--- a/classes/logger.php
+++ b/classes/logger.php
@@ -32,7 +32,7 @@ require_once $CFG->dirroot .'/lib/clilib.php';
  * Class to manage logging actions for this tool.
  * General log table cannot be used for log.info field length restrictions.
  */
-class Logger {
+class tool_mergeusers_logger {
 
     /**
      * Adds a merging action log into tool log.

--- a/cli/climerger.php
+++ b/cli/climerger.php
@@ -35,7 +35,7 @@ require_once $CFG->dirroot . '/lib/clilib.php';
 require_once __DIR__ . '/../lib/autoload.php';
 
 // loads current configuration
-$config = Config::instance();
+$config = tool_mergeusers_config::instance();
 // initializes merger tool
 $mut = new MergeUserTool($config); //may abort execution if database is not supported
 $merger = new Merger($mut);

--- a/lib.php
+++ b/lib.php
@@ -1,0 +1,39 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * mergeusers functions.
+ *
+ * @package    tool_mergeusers
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die;
+
+/**
+ * Gets whether database transactions are allowed.
+ * @global moodle_database $DB
+ * @return bool true if transactions are allowed. false otherwise.
+ */
+function tool_mergeusers_transactionssupported() {
+    global $DB;
+
+    // Tricky way of getting real transactions support, without re-programming it.
+    // May be in the future, as phpdoc shows, this method will be publicly accessible.
+    $method = new ReflectionMethod($DB, 'transactions_supported');
+    $method->setAccessible(true); //method is protected; make it accessible.
+    return $method->invoke($DB);
+}

--- a/lib/merger.php
+++ b/lib/merger.php
@@ -36,7 +36,7 @@ class Merger {
      */
     public function __construct(MergeUserTool $mut) {
         $this->mut = $mut;
-        $this->logger = new Logger();
+        $this->logger = new tool_mergeusers_logger();
 
         // to catch Ctrl+C interruptions, we need this stuff.
         declare(ticks = 1);

--- a/lib/mergeusertool.php
+++ b/lib/mergeusertool.php
@@ -38,6 +38,7 @@ global $CFG;
 
 require_once $CFG->dirroot . '/lib/clilib.php';
 require_once __DIR__ . '/autoload.php';
+require_once($CFG->dirroot . '/'.$CFG->admin.'/tool/mergeusers/lib.php');
 
 /**
  *
@@ -376,22 +377,6 @@ class MergeUserTool
     }
 
     /**
-     * Gets whether database transactions are allowed.
-     * @global moodle_database $DB
-     * @return bool true if transactions are allowed. false otherwise.
-     */
-    public static function transactionsSupported()
-    {
-        global $DB;
-
-        // Tricky way of getting real transactions support, without re-programming it.
-        // May be in the future, as phpdoc shows, this method will be publicly accessible.
-        $method = new ReflectionMethod($DB, 'transactions_supported');
-        $method->setAccessible(true); //method is protected; make it accessible.
-        return $method->invoke($DB);
-    }
-
-    /**
      * Checks whether the current database supports transactions.
      * If settings of this plugin are set up to allow only transactions,
      * this method aborts the execution. Otherwise, this method will return
@@ -403,7 +388,7 @@ class MergeUserTool
     {
         global $CFG;
 
-        $transactionsSupported = self::transactionsSupported();
+        $transactionsSupported = tool_mergeusers_transactionssupported();
         $forceOnlyTransactions = get_config('tool_mergeusers', 'transactions_only');
 
         if (!$transactionsSupported && $forceOnlyTransactions) {

--- a/lib/mergeusertool.php
+++ b/lib/mergeusertool.php
@@ -96,7 +96,7 @@ class MergeUserTool
     protected $userFieldNames;
 
     /**
-     * @var Logger logger for merging users.
+     * @var tool_mergeusers_logger logger for merging users.
      */
     protected $logger;
 
@@ -115,13 +115,13 @@ class MergeUserTool
      * Initializes
      * @global object $CFG
      * @param tool_mergeusers_config $config local configuration.
-     * @param Logger $logger logger facility to save results of mergings.
+     * @param tool_mergeusers_logger $logger logger facility to save results of mergings.
      */
-    public function __construct(tool_mergeusers_config $config = null, Logger $logger = null)
+    public function __construct(tool_mergeusers_config $config = null, tool_mergeusers_logger $logger = null)
     {
         global $CFG;
 
-        $this->logger = (is_null($logger)) ? new Logger() : $logger;
+        $this->logger = (is_null($logger)) ? new tool_mergeusers_logger() : $logger;
         $config = (is_null($config)) ? tool_mergeusers_config::instance() : $config;
         $this->supportedDatabase = true;
 

--- a/lib/mergeusertool.php
+++ b/lib/mergeusertool.php
@@ -113,15 +113,15 @@ class MergeUserTool
     /**
      * Initializes
      * @global object $CFG
-     * @param Config $config local configuration.
+     * @param tool_mergeusers_config $config local configuration.
      * @param Logger $logger logger facility to save results of mergings.
      */
-    public function __construct(Config $config = null, Logger $logger = null)
+    public function __construct(tool_mergeusers_config $config = null, Logger $logger = null)
     {
         global $CFG;
 
         $this->logger = (is_null($logger)) ? new Logger() : $logger;
-        $config = (is_null($config)) ? Config::instance() : $config;
+        $config = (is_null($config)) ? tool_mergeusers_config::instance() : $config;
         $this->supportedDatabase = true;
 
         $this->checkTransactionSupport();

--- a/log.php
+++ b/log.php
@@ -40,7 +40,7 @@ admin_externalpage_setup('tool_mergeusers_viewlog');
 $id = required_param('id', PARAM_INT);
 
 $renderer = $PAGE->get_renderer('tool_mergeusers');
-$logger = new Logger();
+$logger = new tool_mergeusers_logger();
 
 $log = $logger->getDetail($id);
 

--- a/renderer.php
+++ b/renderer.php
@@ -24,6 +24,7 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once __DIR__ . '/select_form.php';
 require_once __DIR__ . '/review_form.php';
+require_once($CFG->dirroot . '/'.$CFG->admin.'/tool/mergeusers/lib.php');
 
 /**
  * Renderer for the merge user plugin.
@@ -194,7 +195,7 @@ class tool_mergeusers_renderer extends plugin_renderer_base
             $dbmessage = 'dbok';
             $notifytype = 'notifysuccess';
         } else {
-            $transactions = (MergeUserTool::transactionsSupported()) ?
+            $transactions = (tool_mergeusers_transactionssupported()) ?
                     '_transactions' :
                     '_no_transactions';
 

--- a/settings.php
+++ b/settings.php
@@ -30,9 +30,10 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-require_once __DIR__ . '/lib/autoload.php';
-
 if ($hassiteconfig) {
+    require_once($CFG->dirroot . '/'.$CFG->admin.'/tool/mergeusers/lib/autoload.php');
+    require_once($CFG->dirroot . '/'.$CFG->admin.'/tool/mergeusers/lib.php');
+
     $ADMIN->add('accounts',
             new admin_category('tool_mergeusers', get_string('pluginname', 'tool_mergeusers')));
     $ADMIN->add('tool_mergeusers',
@@ -53,7 +54,7 @@ if ($hassiteconfig) {
         get_string('suspenduser_setting_desc', 'tool_mergeusers'),
         1));
 
-    $supporting_lang = (MergeUserTool::transactionsSupported()) ? 'transactions_supported' : 'transactions_not_supported';
+    $supporting_lang = (tool_mergeusers_transactionssupported()) ? 'transactions_supported' : 'transactions_not_supported';
 
     $settings->add(new admin_setting_configcheckbox('tool_mergeusers/transactions_only',
         get_string('transactions_setting', 'tool_mergeusers'),

--- a/settings.php
+++ b/settings.php
@@ -61,7 +61,7 @@ if ($hassiteconfig) {
             get_string($supporting_lang, 'tool_mergeusers'),
         1));
 
-    $config = Config::instance();
+    $config = tool_mergeusers_config::instance();
     $none = get_string('none');
     $options = array('none' => $none);
     foreach ($config->exceptions as $exception) {

--- a/view.php
+++ b/view.php
@@ -39,7 +39,7 @@ require_capability('moodle/site:config', context_system::instance());
 
 admin_externalpage_setup('tool_mergeusers_viewlog');
 
-$logger = new Logger();
+$logger = new tool_mergeusers_logger();
 $renderer = $PAGE->get_renderer('tool_mergeusers');
 
 echo $renderer->logs_page($logger->get());


### PR DESCRIPTION
TABLE_SCHEMA == 'public' in Postgres so comparing it to $CFG->dbname causes no fields to be returned.