### PR TITLE
Correct attempts merger sql

### DIFF
--- a/lib/table/quizattemptsmerger.php
+++ b/lib/table/quizattemptsmerger.php
@@ -278,13 +278,11 @@ class QuizAttemptsMerger extends GenericTableMerger
         $idsstr = "'" . implode("', '", $ids) . "'";
 
         $sqlQuizzes = "
-            SELECT DISTINCT q.*
-            FROM
-                {" . $data['tableName'] . "} qo JOIN
-                {quiz} q ON
-                    (q.id = qo.quiz)
-            WHERE
-                qo.id IN ($idsstr)
+            SELECT * FROM {quiz} q
+                    WHERE EXISTS (
+                            SELECT * FROM {" . $data['tableName'] . 
+                                    "} WHERE id IN ($idsstr) AND quiz=q.id
+                                 )
         ";
 
         $quizzes = $DB->get_records_sql($sqlQuizzes);


### PR DESCRIPTION
This updates the SQL which seeks to get a list of which quizzes are associated with a set of grades or attempts. The updates make it more compatible, avoiding an error in MS SQL related to the improper use of DISTINCT, and using SQL which more directly expresses the intent.

The old SQL was:
`SELECT DISTINCT quiz.*  FROM $tableName ... JOIN quiz`

The fact that we're selecting only from quiz means the "FROM $tableName ... JOIN quiz" doesn't quite express the intent, and the use of DISTINCT is code smell indicating a possible error.  A clearer of statement of what we want is:

`SELECT * FROM quiz WHERE id IN (SELECT quiz FROM  $tableName`

I've updated it to use the better-performing synonym:
`SELECT * FROM mdl_quiz WHERE EXISTS ( SELECT * FROM  $tableName`
