### PR TITLE
issue #83 - removed option 'both' for compound indexes and left only 'us...

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -49,45 +49,45 @@ return array(
     // List of compound indexes.
     // This list may vary from Moodle instance to another, given that the Moodle version,
     // local changes and non-core plugins may add new special cases to be processed.
-    // When 'both' field is set, this means that user.id values may appear in the list of 'otherfields' too.
+    // Put in 'userfield' all column names related to a user (i.e., user.id), and all the rest column names
+    // into 'otherfields'.
     // See README.txt for details on special cases.
     // Table names must be without $CFG->prefix.
     'compoundindexes' => array(
         'grade_grades' => array(
-            'userfield' => 'userid',
+            'userfield' => array('userid'),
             'otherfields' => array('itemid'),
         ),
         'groups_members' => array(
-            'userfield' => 'userid',
+            'userfield' => array('userid'),
             'otherfields' => array('groupid'),
         ),
         'journal_entries' => array(
-            'userfield' => 'userid',
+            'userfield' => array('userid'),
             'otherfields' => array('journal'),
         ),
         'course_completions' => array(
-            'userfield' => 'userid',
+            'userfield' => array('userid'),
             'otherfields' => array('course'),
         ),
         'message_contacts' => array(//both fields are user.id values
-            'userfield' => 'userid',
-            'otherfields' => array('contactid'),
-            'both' => true,
+            'userfield' => array('userid', 'contactid'),
+            'otherfields' => array(),
         ),
         'role_assignments' => array(
-            'userfield' => 'userid',
+            'userfield' => array('userid'),
             'otherfields' => array('contextid', 'roleid'), // mdl_roleassi_useconrol_ix (not unique)
         ),
         'user_lastaccess' => array(
-            'userfield' => 'userid',
+            'userfield' => array('userid'),
             'otherfields' => array('courseid'), // mdl_userlast_usecou_ui (unique)
         ),
         'quiz_attempts' => array(
-            'userfield' => 'userid',
+            'userfield' => array('userid'),
             'otherfields' => array('quiz', 'attempt'), // mdl_quizatte_quiuseatt_uix (unique)
         ),
         'cohort_members' => array(
-            'userfield' => 'userid',
+            'userfield' => array('userid'),
             'otherfields' => array('cohortid'),
         ),
     ),

--- a/lib/table/generictablemerger.php
+++ b/lib/table/generictablemerger.php
@@ -231,9 +231,11 @@ class GenericTableMerger implements TableMerger
     }
 
     /**
-     * Gets the fields name on a compound index case. If the compound index only has a
-     * user-related field, always returns the 'otherfields' of the $compoundIndex.
-     * If both fields are user-related, gets the opposite field name.
+     * Gets the fields name on a compound index case, excluding the given $userField.
+     * Therefore, if there are multiple user-related fields in a compound index,
+     * return the rest of the column names except the given $userField. Otherwise,
+     * it returns simply the 'otherfields' array from the $compoundIndex definition.
+     *
      * @param string $userField current user-related field being analyized.
      * @param array $compoundIndex related config data for the compound index.
      * @return array an array with the other field names of the compound index.
@@ -241,19 +243,11 @@ class GenericTableMerger implements TableMerger
     protected function getOtherFieldsOnCompoundIndex($userField, $compoundIndex)
     {
         // we can alternate column names when both fields are user-related.
-        if (isset($compoundIndex['both']) &&
-                $compoundIndex['both'] &&
-                $userField != $compoundIndex['userfield']) {
-
-            // get the list of other fields.
-            $others = array_flip($compoundIndex['otherfields']);
-            // remove the given $userField
-            unset($others[$userField]);
-            $others = array_flip($others);
-            // append the 'userfield'
-            $others[] = $compoundIndex['userfield'];
-            // return all except $userField
-            return $others;
+        if (sizeof($compoundIndex['userfield'])>1) {
+            $all = array_merge($compoundIndex['userfield'], $compoundIndex['otherfields']);
+            $all = array_flip($all);
+            unset($all[$userField]);
+            return array_flip($all);
         }
         // default behavior
         return $compoundIndex['otherfields'];


### PR DESCRIPTION
...erfield' key for all user-related column names.