### PR TITLE
Rework the merge_success event handler into an observer

### DIFF
--- a/db/events.php
+++ b/db/events.php
@@ -27,11 +27,22 @@
  *
  * Available events: merging_sucess, merging_failed
  */
-$handlers = array (
-    'merging_success' => array (
-        'handlerfile'      => '/admin/tool/mergeusers/lib/events/olduser.php',
-        'handlerfunction'  => 'tool_mergeusers_old_user_suspend',
-        'schedule'         => 'instant',
-        'internal'         => 1,
-    ),
-);
+if ($CFG->branch < 26) {
+    $handlers = array(
+        'merging_success' => array(
+            'handlerfile'      => '/admin/tool/mergeusers/lib/events/olduser.php',
+            'handlerfunction'  => 'tool_mergeusers_old_user_suspend',
+            'schedule'         => 'instant',
+            'internal'         => 1,
+        ),
+    );
+} else {
+    $observers = array(
+        array(
+            'eventname'     => 'tool_mergeusers\event\user_merged_success',
+            'callback'      => 'tool_mergeusers_old_user_suspend',
+            'includefile'   => '/admin/tool/mergeusers/lib/events/olduser.php',
+            'internal'      => 1
+        )
+    );
+}

--- a/lib/events/olduser.php
+++ b/lib/events/olduser.php
@@ -34,7 +34,13 @@ require_once $CFG->libdir . '/gdlib.php';
  * @global moodle_database $DB
  */
 function tool_mergeusers_old_user_suspend($event) {
-    global $DB;
+    global $DB, $CFG;
+
+    if ($CFG->branch < 26) {
+        $oldid = $event->oldid;
+    } else {
+        $oldid = $event->other['usersinvolved']['fromid'];
+    }
 
     // Check configuration to see if the old user gets suspended
     $enabled = (int)get_config('tool_mergeusers', 'suspenduser');
@@ -44,7 +50,7 @@ function tool_mergeusers_old_user_suspend($event) {
 
     // 1. update auth type
     $olduser = new stdClass();
-    $olduser->id = $event->oldid;
+    $olduser->id = $oldid;
     $olduser->suspended = 1;
     $olduser->timemodified = time();
     $DB->update_record('user', $olduser);
@@ -57,9 +63,9 @@ function tool_mergeusers_old_user_suspend($event) {
     }
 
     // put the common image as the profile picture.
-    $context = context_user::instance($event->oldid);
+    $context = context_user::instance($oldid);
     if (($newrev = process_new_icon($context, 'user', 'icon', 0, $fullpath))) {
-        $DB->set_field('user', 'picture', $newrev, array('id'=>$event->oldid));
+        $DB->set_field('user', 'picture', $newrev, array('id'=>$oldid));
     }
 
 


### PR DESCRIPTION
Use an observer instead of an event handler for user_merged_success event. If moodle branch >= 26

Stops moodle3.1 depreciation lib from complaining.


