### PR TITLE
Correct double to single quote within SQL query.

### DIFF
--- a/lib/mergeusertool.php
+++ b/lib/mergeusertool.php
@@ -145,7 +145,7 @@ class MergeUserTool
                 break;
             case 'mysqli':
             case 'mariadb':
-                $this->sqlListTables = 'SHOW TABLES like "' . $CFG->prefix . '%"';
+                $this->sqlListTables = "SHOW TABLES like '" . $CFG->prefix . "%'";
                 break;
             case 'pgsql':
                 $this->sqlListTables = "SELECT table_name FROM information_schema.tables WHERE table_name LIKE '" .


### PR DESCRIPTION
Hello,

I've requested merge of a new commit which fixes a quoted string using doublequotes inside a SQL query where it should instead be using singlequotes.  This was encountered on Totara 11 which has stricter database syntax requirements than current Moodle, and causes display of the Merge user accounts page to fail with a SQL syntax error currently.  Please note that I've pushed a commit for both current (master) and previous (MOODLE_33_STABLE) branches, as Totara 11 and 12 are based off older Moodle 3.2 and 3.3, respectively.  Our hope is that this can be fixed for the earlier version as well so it can be deployed on Totara (i.e. requires value not greater than 2016120509.)