### PR TITLE
Update mergeusertool.php

### DIFF
--- a/lib/mergeusertool.php
+++ b/lib/mergeusertool.php
@@ -449,8 +449,8 @@ class MergeUserTool
     private function updateGrades($toid, $fromid) {
         global $DB, $CFG;
         require_once($CFG->libdir.'/gradelib.php');
-
-        $sql = "SELECT DISTINCT gi.iteminstance, gi.itemmodule, gi.courseid
+        $row_id = $DB->sql_concat_join("'_'", ['gi.iteminstance', 'gi.itemmodule', 'gi.courseid']) . ' rowid ';
+        $sql = "SELECT DISTINCT $row_id, gi.iteminstance, gi.itemmodule, gi.courseid
                 FROM {grade_grades} gg
                 INNER JOIN {grade_items} gi on gg.itemid = gi.id
                 WHERE itemtype = 'mod' AND (gg.userid = :toid OR gg.userid = :fromid)";


### PR DESCRIPTION
The update resolves the <<duplicate first field value>> error, as Moodle demands each record to have a unique value for the first field on each database query.