### PR TITLE
228 Add mdl_customcert_issues to compoundindexes

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -134,6 +134,10 @@ return array(
             'userfield' => array('userid'),
             'otherfields' => array('assignment'),
         ),
+        'customcert_issues' => array(
+            'userfield' => array('userid'),
+            'otherfields' => array('customcertid'),
+        ),
     ),
 
     // List of column names per table, where their content is a user.id.


### PR DESCRIPTION
For mod_customcert rows with duplicate (userid, customcertid) are not allowed although this is not specified in mdl_customcert_issues's table definition.  When duplicates are present the message "Did you remember to make the first column something unique in your call to get_records? Duplicate value ... found in column 'id'." occurs.  This commit adds handling for this compound index.