### PR TITLE
Allow for a local configuration file outside of the admin/tool/mergeusers directory so it can be tracked by git

### DIFF
--- a/classes/tool_mergeusers_config.php
+++ b/classes/tool_mergeusers_config.php
@@ -72,6 +72,11 @@ class tool_mergeusers_config {
             $localconfig = include dirname(__DIR__) . '/config/config.local.php';
             $config = array_replace_recursive($config, $localconfig);
         }
+		$outerLocalConfigFile = dirname(__DIR__) . '/../mergeusers.config.local.php';
+		if (file_exists($outerLocalConfigFile)) {
+			$outerLocalConfig = include $outerLocalConfigFile;
+			$config = array_replace_recursive($config, $outerLocalConfig);
+		}
         $this->config = $config;
     }
 

--- a/classes/tool_mergeusers_config.php
+++ b/classes/tool_mergeusers_config.php
@@ -72,11 +72,11 @@ class tool_mergeusers_config {
             $localconfig = include dirname(__DIR__) . '/config/config.local.php';
             $config = array_replace_recursive($config, $localconfig);
         }
-		$outerLocalConfigFile = dirname(__DIR__) . '/../mergeusers.config.local.php';
-		if (file_exists($outerLocalConfigFile)) {
-			$outerLocalConfig = include $outerLocalConfigFile;
-			$config = array_replace_recursive($config, $outerLocalConfig);
-		}
+        $outerLocalConfigFile = dirname(__DIR__) . '/../mergeusers.config.local.php';
+        if (file_exists($outerLocalConfigFile)) {
+            $outerLocalConfig = include $outerLocalConfigFile;
+            $config = array_replace_recursive($config, $outerLocalConfig);
+        }
         $this->config = $config;
     }
 


### PR DESCRIPTION
Simple change for a configuration file right next to the mergeusers/ directory.

My project is all tracked in git, and customizations that we make to the merging also need to be included. Those can't be inside a submodule, so this allows for another local configuration file outside the submodule.