### PR TITLE
Add user profile fields for merge information once the process is completed

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ This plugin also manages the 'merging_success' event is trigered, what includes:
 2. Changing the old user's profile picture by the given on pix/suspended.jpg. It is a simple
    white image with the text "suspended user", which could help to teachers and
    managers to rapidly detect them.
+3. Add merge date in user profile field (merge_date), after the merge process was successful.
+4. Add merge info in user profile field (merge_info) on which user was merged into the other one.
 
 
 Correct way of testing this plugin

--- a/classes/event/user_merged_success.php
+++ b/classes/event/user_merged_success.php
@@ -46,4 +46,15 @@ class user_merged_success extends user_merged {
             from '{$this->other['usersinvolved']['fromid']}' into '{$this->other['usersinvolved']['toid']}'";
     }
 
+    public function get_log_id(): int {
+        return $this->other['logid'] ?? 0;
+    }
+
+    public function get_new_user_id(): int {
+        return $this->other['usersinvolved']['toid'] ?? 0;
+    }
+
+    public function get_old_user_id(): int {
+        return $this->other['usersinvolved']['fromid'] ?? 0;
+    }
 }

--- a/classes/local/observer/user_profile_field_info.php
+++ b/classes/local/observer/user_profile_field_info.php
@@ -1,0 +1,116 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * @package tool
+ * @subpackage mergeusers
+ * @author Sam Møller <smo@moxis.dk>
+ * @copyright 2019 Servei de Recursos Educatius (http://www.sre.urv.cat)
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_mergeusers\local\observer;
+
+use tool_mergeusers\event\user_merged_success;
+
+// @codeCoverageIgnoreStart
+defined('MOODLE_INTERNAL') || die();
+// @codeCoverageIgnoreEnd
+
+
+global $CFG;
+require_once $CFG->dirroot . '/user/profile/lib.php';
+
+class user_profile_field_info {
+    public static function add_merge_date_info(user_merged_success $event): void {
+        try {
+            $old_user_id = $event->get_old_user_id();
+            $new_user_id = $event->get_new_user_id();
+
+            $users = self::get_users_by_ids([$old_user_id, $new_user_id]);
+
+            $info = [
+                'newuserid' => $new_user_id,
+                'newusername' => $users[$new_user_id]->username,
+                'olduserid' => $old_user_id,
+                'oldusername' => $users[$old_user_id]->username,
+                'logurl' => self::get_log_url($event->get_log_id())->out(false)
+            ];
+
+            self::add_merge_info(
+                $old_user_id,
+                get_string(
+                    'userfieldmergeto',
+                    'tool_mergeusers',
+                    $info
+                ),
+                time()
+            );
+
+            self::clear_merge_info($new_user_id);
+
+        } catch (\Exception $e) {
+            // Do nothing
+        }
+    }
+
+    private static function get_users_by_ids(array $ids): array {
+        global $DB;
+
+        if (empty($ids)) {
+            return [];
+        }
+
+        [$in_sql, $params] = $DB->get_in_or_equal($ids);
+
+        return $DB->get_records_select(
+            'user',
+            "id $in_sql",
+            $params,
+            'id, username',
+            'id, username'
+        );
+    }
+
+    private static function add_merge_info(int $user_id, string $info, ?int $time = null): void {
+        $fields = [
+            'merge_info' => $info
+        ];
+
+        if ($time !== null) {
+            $fields['merge_date'] = $time;
+        }
+
+        profile_save_custom_fields($user_id, $fields);
+    }
+
+    private static function clear_merge_info(int $user_id): void {
+        $fields = [
+            'merge_info' => '',
+            'merge_date' => null
+        ];
+        profile_save_custom_fields($user_id, $fields);
+    }
+
+    private static function get_log_url(
+        int $log_id
+    ): \moodle_url {
+        return new \moodle_url(
+            '/admin/tool/mergeusers/log.php',
+            ['id' => $log_id]
+        );
+    }
+}

--- a/db/events.php
+++ b/db/events.php
@@ -38,4 +38,9 @@ $observers = array(
         'callback'      => '\tool_mergeusers\local\observer\keptuser::make_kept_user_as_not_suspended',
         'internal'      => 1
     ),
+    array(
+        'eventname'     => 'tool_mergeusers\event\user_merged_success',
+        'callback'      => '\tool_mergeusers\local\observer\user_profile_field_info::add_merge_date_info',
+        'internal'      => 1
+    )
 );

--- a/db/install.php
+++ b/db/install.php
@@ -1,0 +1,30 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * @package tool
+ * @subpackage mergeusers
+ * @author Sam Møller <smo@moxis.dk>
+ * @copyright 2019 Servei de Recursos Educatius (http://www.sre.urv.cat)
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+function xmldb_tool_mergeusers_install(): void {
+    global $CFG;
+    require_once $CFG->dirroot . '/admin/tool/mergeusers/lib.php';
+
+    tool_mergeusers_create_user_profile_fields();
+}

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -30,7 +30,8 @@
  * @return boolean true when success, false on error.
  */
 function xmldb_tool_mergeusers_upgrade ($oldversion) {
-    global $DB;
+    global $CFG, $DB;
+    require_once $CFG->dirroot . '/admin/tool/mergeusers/lib.php';
 
     $dbman = $DB->get_manager();
 
@@ -78,6 +79,14 @@ function xmldb_tool_mergeusers_upgrade ($oldversion) {
 
         // Mergeusers savepoint reached.
         upgrade_plugin_savepoint(true, 2023040401, 'tool', 'mergeusers');
+    }
+
+    if ($oldversion < 2024111400) {
+        // Try to create custom fields
+        tool_mergeusers_create_user_profile_fields();
+
+        // Mergeusers savepoint reached.
+        upgrade_plugin_savepoint(true, 2024111400, 'tool', 'mergeusers');
     }
 
     return true;

--- a/lang/en/tool_mergeusers.php
+++ b/lang/en/tool_mergeusers.php
@@ -82,6 +82,8 @@ $string['errortransactionsonly'] = 'Error: transactions are required, but your d
     Please, review plugin settings to set up them accordingly.';
 $string['eventusermergedsuccess'] = 'Merging success';
 $string['eventusermergedfailure'] = 'Merge failed';
+$string['userfieldmergeto'] = 'Data from this user was successfully merged into {$a->newusername}';
+$string['userfieldmergefrom'] = 'Data from {$a->oldusername} has been merged into this user. See more {$a->logurl}';
 
 // Settings page.
 $string['transactions_setting'] = 'Only transactions allowed';

--- a/lib.php
+++ b/lib.php
@@ -81,3 +81,77 @@ function tool_mergeusers_build_quiz_options() {
 
     return $result;
 }
+
+/**
+ * Create user profile fields for user metadata once users have been merged.
+ * @return void
+ */
+function tool_mergeusers_create_user_profile_fields(): void {
+    global $CFG, $DB;
+
+    require_once $CFG->dirroot . '/user/profile/lib.php';
+    require_once $CFG->dirroot . '/user/profile/definelib.php';
+
+    // Create user profile field category
+    $category_name = 'Merge User Info';
+    $category = $DB->get_record('user_info_category', ['name' => $category_name]);
+
+    if (empty($category)) {
+        $category = (object)[
+            'name' => $category_name,
+        ];
+        profile_save_category($category);
+    }
+
+
+    // Skip if category is not found
+    if (!isset($category->id)) {
+        return;
+    }
+
+    $fields = [
+        'merge_date' => [
+            'name' => 'Merge Date',
+            'shortname' => 'merge_date',
+            'datatype' => 'datetime',
+            'description' => '',
+            'descriptionformat' => FORMAT_HTML,
+            'categoryid' => $category->id,
+            'required' => false,
+            'locked' => false,
+            'visible' => false,
+            'forceunique' => false,
+            'signup' => false,
+            'defaultdata' => 0,
+            'defaultdataformat' => '0',
+            'param1' => '2024',
+            'param2' => '2024',
+        ],
+        'merge_info' => [
+            'name' => 'Merge Info',
+            'shortname' => 'merge_info',
+            'datatype' => 'text',
+            'description' => '',
+            'descriptionformat' => FORMAT_HTML,
+            'categoryid' => $category->id,
+            'required' => false,
+            'locked' => false,
+            'visible' => false,
+            'forceunique' => false,
+            'signup' => false,
+            'defaultdata' => '',
+            'defaultdataformat' => '0',
+            'param1' => '30',
+            'param2' => '2048',
+            'param3' => '0',
+        ],
+    ];
+
+    // Create custom fields if they do not exist
+    foreach ($fields as $field_info) {
+        $record = (object)$field_info;
+
+        $define_field = new profile_define_base();
+        $define_field->define_save($record);
+    }
+}

--- a/lib/mergeusertool.php
+++ b/lib/mergeusertool.php
@@ -194,6 +194,8 @@ class MergeUserTool
         $eventpath = "\\tool_mergeusers\\event\\";
         $eventpath .= ($success) ? "user_merged_success" : "user_merged_failure";
 
+        $logid = $this->logger->log($toid, $fromid, $success, $log);
+
         $event = $eventpath::create(array(
             'context' => \context_system::instance(),
             'other' => array(
@@ -201,11 +203,12 @@ class MergeUserTool
                     'toid' => $toid,
                     'fromid' => $fromid,
                 ),
+                'logid' => $logid,
                 'log' => $log,
             ),
         ));
         $event->trigger();
-        $logid = $this->logger->log($toid, $fromid, $success, $log);
+
         return array($success, $log, $logid);
     }
 

--- a/lib/table/assignsubmissiontablemerger.php
+++ b/lib/table/assignsubmissiontablemerger.php
@@ -26,7 +26,8 @@ require_once(__DIR__ . '/../db/dbassignsubmission.php');
 
 class AssignSubmissionTableMerger extends GenericTableMerger {
 
-    private $findassignsubmissions;
+    private db_assign_submission $findassignsubmissions;
+    private AssignSubmissionDuplicatedDataMerger $duplicateddatamerger;
 
     public function __construct() {
         parent::__construct(new AssignSubmissionDuplicatedDataMerger());

--- a/tests/user_profile_field_info_test.php
+++ b/tests/user_profile_field_info_test.php
@@ -1,0 +1,203 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * @package tool
+ * @subpackage mergeusers
+ * @author Sam Møller <smo@moxis.dk>
+ * @copyright 2019 Servei de Recursos Educatius (http://www.sre.urv.cat)
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+class user_profile_field_info_test extends advanced_testcase {
+    protected function setUp(): void {
+        global $CFG;
+
+        require_once $CFG->dirroot . '/admin/tool/mergeusers/lib.php';
+
+        $this->resetAfterTest();
+    }
+
+    /**
+     * Find existing user profile category.
+     * Remove it if it exists.
+     * Create by calling the function.
+     * Check if it exists.
+     */
+    public function test_create_user_profile_category(): void {
+        global $DB;
+
+        $category = $this->get_merge_users_profile_category();
+        $old_id = $category->id;
+
+        if (!empty($category->id)) {
+            $DB->delete_records('user_info_category', ['id' => $category->id]);
+        }
+
+        tool_mergeusers_create_user_profile_fields();
+
+        $category = $DB->get_record('user_info_category', ['name' => $category->name]);
+
+        self::assertNotEmpty($category->id);
+        self::assertNotEquals($old_id, $category->id);
+    }
+
+    /**
+     * Get the merge user profile category.
+     * Remove all fields in the category.
+     * Call the function to create the fields.
+     * Check if the fields exist.
+     */
+    public function test_create_user_profile_fields(): void {
+        global $DB;
+
+        $category = $this->get_merge_users_profile_category();
+
+        // Remove all fields in the category.
+        $DB->delete_records('user_info_field', ['categoryid' => $category->id]);
+
+        tool_mergeusers_create_user_profile_fields();
+
+        $records = $DB->get_recordset('user_info_field', ['categoryid' => $category->id]);
+        $fields = [];
+
+        foreach ($records as $record) {
+            $fields[$record->shortname] = $record;
+        }
+
+        $records->close();
+
+        self::assertArrayHasKey('merge_date', $fields);
+        self::assertArrayHasKey('merge_info', $fields);
+    }
+
+    /**
+     * Emit user_merged_success event.
+     * Call the function to add merge date and info (add_merge_date_info).
+     * Check if the fields have been updated on old user and new user.
+     */
+    public function test_event_observer_add_merge_date_and_info(): void {
+        global $DB;
+
+        $category = $this->get_merge_users_profile_category();
+        [$in_sql, $field_params] = $DB->get_in_or_equal(['merge_date', 'merge_info']);
+        $field_params[] = $category->id;
+
+        $field_exists = $DB->record_exists_select(
+            'user_info_field',
+            "shortname $in_sql AND categoryid = ?",
+            $field_params
+        );
+
+        self::assertTrue($field_exists);
+
+        $generator = self::getDataGenerator();
+
+        $old_user = $generator->create_user();
+        $new_user = $generator->create_user();
+        $log = (object)[
+            'id' => 1,
+            'touserid' => $new_user->id,
+            'fromuserid' => $old_user->id,
+            'mergedbyuserid' => 2,
+            'timemodified' => time(),
+            'log' => '',
+        ];
+
+        $event = $this->get_user_merged_success_event($old_user, $new_user, $log);
+
+        \tool_mergeusers\local\observer\user_profile_field_info::add_merge_date_info($event);
+
+        $old_user_fields = $this->get_profile_fields_with_shortnames(
+            $category->id,
+            $old_user->id
+        );
+
+        self::assertGreaterThan(
+            0,
+            $old_user_fields['merge_date']->data
+        );
+        self::assertStringContainsString(
+            $new_user->username,
+            $old_user_fields['merge_info']->data
+        );
+
+        $new_user_fields = $this->get_profile_fields_with_shortnames(
+            $category->id,
+            $new_user->id
+        );
+
+        self::assertEmpty(
+            $new_user_fields['merge_date']->data
+        );
+        self::assertEmpty(
+            $new_user_fields['merge_info']->data
+        );
+    }
+
+    private function get_merge_users_profile_category(): object {
+        global $DB;
+
+        $record = ['name' => 'Merge User Info'];
+        $category = $DB->get_record('user_info_category', $record);
+
+        if (empty($category)) {
+            $category = self::getDataGenerator()->create_custom_profile_field_category($record);
+        }
+
+        return $category;
+    }
+
+    /**
+     * @param int $profile_category_id
+     * @param int $user_id
+     * @return profile_field_base[]
+     */
+    private function get_profile_fields_with_shortnames(int $profile_category_id, int $user_id): array {
+        $category_fields = profile_get_user_fields_with_data_by_category($user_id);
+        $items = [];
+
+        if (!isset($category_fields[$profile_category_id])) {
+            return $items;
+        }
+
+        foreach ($category_fields as $fields) {
+            foreach ($fields as $field) {
+                $items[$field->get_shortname()] = $field;
+            }
+        }
+
+        return $items;
+    }
+
+    private function get_user_merged_success_event(
+        object $old_user,
+        object $new_user,
+        object $log
+    ): \tool_mergeusers\event\user_merged_success {
+        return \tool_mergeusers\event\user_merged_success::create([
+            'context' => \context_system::instance(),
+            'other' => [
+                'usersinvolved' => [
+                    'toid' => $new_user->id,
+                    'fromid' => $old_user->id,
+                ],
+                'logid' => $log->id,
+                'log' => $log,
+            ],
+        ]);
+    }
+}

--- a/version.php
+++ b/version.php
@@ -30,7 +30,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2024060300;
+$plugin->version   = 2024111400;
 $plugin->requires  = 2023042400; // Moodle 4.2, 24 April 2023, https://moodledev.io/general/releases#moodle-42
 $plugin->component = 'tool_mergeusers';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Changes log:
* Add 2 new user profile fields. Use for set merge information after merge process is completed.
  * Add field: ``merge_date``
  * Add field: ``merge_info``
* Create new user profile fields on installation and upgrade.

Related issue: https://github.com/jpahullo/moodle-tool_mergeusers/issues/283
