### PR TITLE
Fix PHP 8.1+ deprecation warnings in CLIGathering class

### DIFF
--- a/lib/cligathering.php
+++ b/lib/cligathering.php
@@ -59,7 +59,7 @@ class CLIGathering implements Gathering {
     /**
      * Asks by command line both users to merge, with a header telling what to do.
      */
-    public function rewind()
+    public function rewind(): void
     {
         cli_heading(get_string('pluginname', 'tool_mergeusers'));
         echo get_string('cligathering:description', 'tool_mergeusers') . "\n\n";
@@ -71,7 +71,7 @@ class CLIGathering implements Gathering {
      * Asks for the next pair of users' id to merge.
      * It also detects when anything but a number is introduced, to re-ask for any user id.
      */
-    public function next()
+    public function next(): void
     {
         $record = new stdClass();
 
@@ -104,7 +104,7 @@ class CLIGathering implements Gathering {
      * @return bool true if to go on with the iteration (we have a pair of users to merge).
      * false to conclude.
      */
-    public function valid()
+    public function valid(): bool
     {
         return !$this->end;
     }
@@ -113,7 +113,7 @@ class CLIGathering implements Gathering {
      * Gets the current pair of users to merge.
      * @return stdClass object with fromid and toid fields
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->current;
     }
@@ -122,7 +122,7 @@ class CLIGathering implements Gathering {
      * Gets current int zero-based index.
      * @return int zero-based index value
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->index;
     }


### PR DESCRIPTION
- Added explicit return type declarations for Iterator interface methods:
  * rewind(): void
  * next(): void
  * valid(): bool
  * current(): mixed
  * key(): mixed
- Resolved PHP 8.1+ deprecation warnings about incompatible method signatures
- Ensured compliance with PHP 8.1+ strict return type requirements