### PR TITLE
Remove table borders in Moodle ≥ 5.0, resolves #379.

### DIFF
--- a/classes/output/review_user_form.php
+++ b/classes/output/review_user_form.php
@@ -118,7 +118,7 @@ class review_user_form extends moodleform {
             $mform->disable_form_change_checker();
         }
         $htmltable = new html_table();
-        $htmltable->attributes['class'] = 'clearfix';
+        $htmltable->attributes['class'] = 'clearfix table-reboot';
         $htmltable->data = $buttonarray;
 
         $mform->addElement('static', 'buttonar', '', html_writer::table($htmltable));

--- a/classes/output/user_review_table.php
+++ b/classes/output/user_review_table.php
@@ -93,7 +93,7 @@ class user_review_table extends html_table implements renderable {
 
         // Show the selected users to merge. At least, there is one selected user for merging.
         $this->id = 'merge_users_tool_user_review_table';
-        $this->attributes['class'] = 'generaltable boxaligncenter';
+        $this->attributes['class'] = 'generaltable table-reboot boxaligncenter';
 
         if (
             (isset($this->olduser->idnumber) && !empty($this->olduser->idnumber))

--- a/classes/output/user_select_table.php
+++ b/classes/output/user_select_table.php
@@ -73,7 +73,7 @@ class user_select_table extends html_table implements renderable {
         $this->data = [];
 
         $this->id = 'merge_users_tool_user_select_table';
-        $this->attributes['class'] = 'generaltable boxaligncenter';
+        $this->attributes['class'] = 'generaltable table-reboot boxaligncenter';
 
         $columns = [
             'col_select_olduser' => get_string('olduser', 'tool_mergeusers'),


### PR DESCRIPTION
Note this uses Moodle 5.0.3. Class table-reset was introduced there.

<img width="1392" height="837" alt="image" src="https://github.com/user-attachments/assets/1c36414f-a490-42f9-a25d-a74bbf5a3cdd" />
