### PR TITLE
Moodle 405 search by profile

### DIFF
--- a/index.php
+++ b/index.php
@@ -160,7 +160,15 @@ if (!empty($option)) {
 } else if ($data) {
     // If there is a search argument use this instead of advanced form.
     if (!empty($data->searchgroup['searcharg'])) {
-        $searchedusers = $usersearcher->search_users($data->searchgroup['searcharg'], $data->searchgroup['searchfield']);
+        $selectedfield = trim($data->searchgroup['searchfield']);
+        $pattern = '/^profile_field_([1-9][0-9]*)/';
+        if (preg_match($pattern, $selectedfield, $matches)) {
+            // Profile field.
+            $profilefieldid = $matches[1];
+            $searchedusers = $usersearcher->search_users($data->searchgroup['searcharg'], $profilefieldid);
+        } else {
+            $searchedusers = $usersearcher->search_users($data->searchgroup['searcharg'], $data->searchgroup['searchfield']);
+        }
         $userselecttable = new user_select_table($searchedusers, $renderer);
 
         echo $renderer->index_page($mergeuserform, $renderer::INDEX_PAGE_SEARCH_AND_SELECT_STEP, $userselecttable);

--- a/lang/en/tool_mergeusers.php
+++ b/lang/en/tool_mergeusers.php
@@ -98,6 +98,10 @@ $string['quizattemptsaction_desc'] = 'When merging quiz attempts there may exist
 $string['results'] = 'Merge results and log';
 $string['review_users'] = 'Confirm users to merge';
 $string['saveselection_submit'] = 'Save selection';
+$string['searchbyprofilefields'] = 'Search by profile fields';
+$string['searchbyprofilefields_desc'] = 'Select custom user profile fields allowed for users search
+    <br/> Selecting "none" removes the option for searching by user profile field.
+    <br/> "Any"  allow search by any allowed profile field.';
 $string['searchuser'] = 'Search for User';
 $string['searchuser_help'] = 'Enter the expression you want to match for a specific user field. Only Id makes exact match. The rest of user fields provides partial matching. You can also search for all supported user fields at once.';
 $string['setting:invalidjson'] = 'Invalid JSON content.';

--- a/lang/en/tool_mergeusers.php
+++ b/lang/en/tool_mergeusers.php
@@ -112,6 +112,7 @@ $string['settings:customdbsettingsdesc'] = 'Specify the custom database settings
 $string['settings:databasesettings'] = 'Database settings';
 $string['settings:defaultdbsettings'] = 'Default database settings from <code>default_db_config.php</code>';
 $string['settings:generalsettings'] = 'General settings';
+$string['settings:searchbyprofilefieldssettings'] = 'Search by profile fields settings';
 $string['starttime'] = 'Merge started at {$a}';
 $string['suspenduser_setting'] = 'Suspend old user';
 $string['suspenduser_setting_desc'] = 'If enabled, it suspends the old user automatically upon a successful merge process, preventing the user from logging in Moodle (recommended). If disabled, the old user remains active. In both cases, old user will not have his/her related data.';

--- a/settings.php
+++ b/settings.php
@@ -177,6 +177,18 @@ if ($ADMIN->fulltree) {
         ));
     }
 
+    // Search by Profile fields.
+    $profilefieldsoptions = tool_mergeusers_build_profilefields_options();
+    if ($profilefieldsoptions->options) {
+        $generalsettings->add(new admin_setting_configmultiselect(
+            'tool_mergeusers/searchbyprofilefields',
+            get_string('searchbyprofilefields', 'tool_mergeusers'),
+            get_string('searchbyprofilefields_desc', 'tool_mergeusers', $profilefieldsoptions->defaultvalue),
+            [$profilefieldsoptions->defaultkey], // Default value: none.
+            $profilefieldsoptions->options
+        ));
+    }
+
     // Add database settings.
     if ($showtabs) {
         $databasesettings->add($tabs);

--- a/settings.php
+++ b/settings.php
@@ -75,6 +75,11 @@ $databasesettings = new admin_settingpage(
     new lang_string('settings:databasesettings', 'tool_mergeusers'),
     'moodle/site:config',
 );
+$searchbyprofilefieldssettings = new admin_settingpage(
+    'toolmergeuserssearchbyprofilefieldssettings',
+    new lang_string('settings:searchbyprofilefieldssettings', 'tool_mergeusers'),
+    'moodle/site:config',
+);
 
 // Build just the links on the settings page.
 if ($hassiteconfig) {
@@ -87,6 +92,7 @@ if ($hassiteconfig) {
     );
 
     $ADMIN->add('toolmergeuserscat', $generalsettings);
+    $ADMIN->add('toolmergeuserscat', $searchbyprofilefieldssettings);
     $ADMIN->add('toolmergeuserscat', $databasesettings);
 }
 
@@ -98,6 +104,11 @@ if ($ADMIN->fulltree) {
             'toolmergeusersgeneralsettings',
             new moodle_url('/admin/settings.php', ['section' => 'toolmergeusersgeneralsettings']),
             new lang_string('settings:generalsettings', 'tool_mergeusers'),
+        ),
+        new tabobject(
+            'toolmergeuserssearchbyprofilefieldssettings',
+            new moodle_url('/admin/settings.php', ['section' => 'toolmergeuserssearchbyprofilefieldssettings']),
+            new lang_string('settings:searchbyprofilefieldssettings', 'tool_mergeusers'),
         ),
         new tabobject(
             'toolmergeusersdatabasesettings',
@@ -178,9 +189,13 @@ if ($ADMIN->fulltree) {
     }
 
     // Search by Profile fields.
+    // Add general settings.
+    if ($showtabs) {
+        $searchbyprofilefieldssettings->add($tabs);
+    }
     $profilefieldsoptions = tool_mergeusers_build_profilefields_options();
     if ($profilefieldsoptions->options) {
-        $generalsettings->add(new admin_setting_configmultiselect(
+        $searchbyprofilefieldssettings->add(new admin_setting_configmultiselect(
             'tool_mergeusers/searchbyprofilefields',
             get_string('searchbyprofilefields', 'tool_mergeusers'),
             get_string('searchbyprofilefields_desc', 'tool_mergeusers', $profilefieldsoptions->defaultvalue),

--- a/settingslib.php
+++ b/settingslib.php
@@ -123,3 +123,29 @@ function tool_mergeusers_inform_about_pending_user_profile_fields(): stdClass {
         'url' => (new moodle_url('/user/profile/index.php'))->out(false),
     ];
 }
+
+/**
+ * Build options for search by user profile settings.
+ *
+ * @return stdClass instance with optionnals profil fields that can be enable for searching users.
+ */
+function tool_mergeusers_build_profilefields_options() {
+    global $CFG;
+    require_once($CFG->dirroot . '/user/filters/profilefield.php');
+    $userprofile = new \user_filter_profilefield('profile', get_string('profilefields', 'admin'), false);
+    $profilefields = $userprofile->get_profile_fields();
+
+    $none = get_string('none');
+    $options = [-1 => $none];
+    if (array_diff_key($profilefields, [0 => get_string('anyfield', 'filters')])) {
+        foreach ($profilefields as $fieldid => $fieldname) {
+            $options[$fieldid] = $fieldname;
+        }
+    }
+    $result = new \stdClass();
+    $result->defaultkey = -1;
+    $result->defaultvalue = $none;
+    $result->options = $options;
+
+    return $result;
+}

--- a/tests/searchbyprofilefields_test.php
+++ b/tests/searchbyprofilefields_test.php
@@ -1,0 +1,149 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_mergeusers;
+
+use advanced_testcase;
+use tool_mergeusers\local\user_merger;
+use tool_mergeusers\local\user_searcher;
+
+/**
+ * Merge users searched by profile fields.
+ *
+ * Inspired by enrolments_test.php and user/tests/profilelib_test.php
+ * @package    tool_mergeusers
+ * @covers \MergeUserSearch
+ * @author     Johnny Tsheke
+ * @copyright  Johnny Tsheke
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class searchbyprofilefields_test extends \advanced_testcase {
+    /**
+     * Setup the test.
+     */
+    public function setUp(): void {
+        global $CFG;
+        require_once("{$CFG->dirroot}/user/profile/lib.php");
+        parent::setUp();
+        $this->resetAfterTest(true);
+    }
+
+    /**
+     * Enrol two users on one unique course each and one shared course.
+     * Search each user by a profile field value then merge them.
+     *
+     * @group tool_mergeusers
+     * @group tool_mergeusers_profilefields
+     */
+    public function test_searchbyprofilefields(): void {
+        global $DB;
+        $userone = $this->getDataGenerator()->create_user();
+
+         // Add custom field of normal text type.
+         $fieldid = $this->getDataGenerator()->create_custom_profile_field([
+            'shortname' => 'frogname', 'name' => 'Name of frog',
+            'datatype' => 'text', ])->id;
+         // Check that profile field was created.
+        $results = profile_get_custom_fields();
+        $this->assertArrayHasKey($fieldid, $results);
+        $this->assertEquals('frogname', $results[$fieldid]->shortname);
+        // Add userone profile data.
+        $uidone = new \stdClass();
+        $uidone->userid = $userone->id;
+        $uidone->fieldid = $fieldid;
+        $uidone->data = 'frogvalueone';
+        $DB->insert_record('user_info_data', $uidone);
+
+        // Search tool for searching for users and verifying them.
+        $mus = new user_searcher();
+        $searchusers = $mus->search_users('frogvalueone', $fieldid);
+        $this->assertCount(1, $searchusers);
+
+        // Create the another user.
+        $usertwo = $this->getDataGenerator()->create_user();
+
+        // Add usertwo profile data.
+        $uidtwo = new \stdClass();
+        $uidtwo->userid = $usertwo->id;
+        $uidtwo->fieldid = $fieldid;
+        $uidtwo->data = 'frogvaluetwo';
+        $DB->insert_record('user_info_data', $uidtwo);
+        $searchusers = $mus->search_users('frogvaluetwo', $fieldid);
+        $this->assertCount(1, $searchusers);
+
+        // Check that search by profile field finds all users.
+        $searchusers = $mus->search_users('frogvalue', $fieldid);
+        $this->assertCount(2, $searchusers);
+
+        // Check that userone and usertwo are not suspended.
+        $this->assertEquals(0, $userone->suspended);
+        $this->assertEquals(0, $usertwo->suspended);
+
+        // Create three courses.
+        $course1 = $this->getDataGenerator()->create_course();
+        $course2 = $this->getDataGenerator()->create_course();
+        $course3 = $this->getDataGenerator()->create_course();
+
+        $maninstance1 = $DB->get_record('enrol', ['courseid' => $course1->id, 'enrol' => 'manual'], '*', MUST_EXIST);
+        $maninstance2 = $DB->get_record('enrol', ['courseid' => $course2->id, 'enrol' => 'manual'], '*', MUST_EXIST);
+        $maninstance3 = $DB->get_record('enrol', ['courseid' => $course3->id, 'enrol' => 'manual'], '*', MUST_EXIST);
+
+        $manual = enrol_get_plugin('manual');
+
+        $studentrole = $DB->get_record('role', ['shortname' => 'student']);
+
+        // Enrol $user2 on course 1 + 2 and $user1 on course 2 + 3.
+        $manual->enrol_user($maninstance1, $usertwo->id, $studentrole->id);
+        $manual->enrol_user($maninstance2, $usertwo->id, $studentrole->id);
+        $manual->enrol_user($maninstance2, $userone->id, $studentrole->id);
+        $manual->enrol_user($maninstance3, $userone->id, $studentrole->id);
+
+        // Check initial state of enrolments for $usertwo.
+        $courses = enrol_get_all_users_courses($usertwo->id);
+        ksort($courses);
+        $this->assertCount(2, $courses);
+        $this->assertEquals([$course1->id, $course2->id], array_keys($courses));
+
+        // Check initial state of enrolments for $userone.
+        $courses = enrol_get_all_users_courses($userone->id);
+        ksort($courses);
+        $this->assertCount(2, $courses);
+        $this->assertEquals([$course2->id, $course3->id], array_keys($courses));
+
+        // Search users by profile field and merge userwon into userone.
+        $userkeep = $mus->search_users('frogvalueone', $fieldid)[$userone->id];
+        $userremove = $mus->search_users('frogvaluetwo', $fieldid)[$usertwo->id];
+        $mut = new user_merger();
+        [$success, $log, $logid] = $mut->merge($userkeep->id, $userremove->id);
+
+        // Check userone still not suspended but usertwo is now suspended.
+        $userone = $DB->get_record('user', ['id' => $userone->id]);
+        $this->assertEquals(0, $userone->suspended);
+
+        $usertwo = $DB->get_record('user', ['id' => $usertwo->id]);
+        $this->assertEquals(1, $usertwo->suspended);
+
+        // Check userone is now enrolled on all three courses.
+        $courses = enrol_get_all_users_courses($userone->id);
+        ksort($courses);
+        $this->assertCount(3, $courses);
+        $this->assertEquals([$course1->id, $course2->id, $course3->id], array_keys($courses));
+
+        // Check usertwo is no longer enrolled on any course.
+        $courses = enrol_get_all_users_courses($usertwo->id);
+        $this->assertCount(0, $courses);
+    }
+}

--- a/tests/searchbyprofilefields_test.php
+++ b/tests/searchbyprofilefields_test.php
@@ -97,19 +97,20 @@ final class searchbyprofilefields_test extends \advanced_testcase {
         $course2 = $this->getDataGenerator()->create_course();
         $course3 = $this->getDataGenerator()->create_course();
 
-        $maninstance1 = $DB->get_record('enrol', ['courseid' => $course1->id, 'enrol' => 'manual'], '*', MUST_EXIST);
-        $maninstance2 = $DB->get_record('enrol', ['courseid' => $course2->id, 'enrol' => 'manual'], '*', MUST_EXIST);
-        $maninstance3 = $DB->get_record('enrol', ['courseid' => $course3->id, 'enrol' => 'manual'], '*', MUST_EXIST);
+        $maninstance1 = $DB->get_record('enrol', ['enrol' => 'manual', 'courseid' => $course1->id], '*', MUST_EXIST);
+        $maninstance2 = $DB->get_record('enrol', ['enrol' => 'manual', 'courseid' => $course2->id], '*', MUST_EXIST);
+        $maninstance3 = $DB->get_record('enrol', ['enrol' => 'manual', 'courseid' => $course3->id], '*', MUST_EXIST);
 
         $manual = enrol_get_plugin('manual');
 
         $studentrole = $DB->get_record('role', ['shortname' => 'student']);
 
-        // Enrol $user2 on course 1 + 2 and $user1 on course 2 + 3.
-        $manual->enrol_user($maninstance1, $usertwo->id, $studentrole->id);
-        $manual->enrol_user($maninstance2, $usertwo->id, $studentrole->id);
+        // Enrol  $user1 on course 2 + 3 and $user2 on course 1 + 2.
         $manual->enrol_user($maninstance2, $userone->id, $studentrole->id);
         $manual->enrol_user($maninstance3, $userone->id, $studentrole->id);
+        $manual->enrol_user($maninstance1, $usertwo->id, $studentrole->id);
+        $manual->enrol_user($maninstance2, $usertwo->id, $studentrole->id);
+        
 
         // Check initial state of enrolments for $usertwo.
         $courses = enrol_get_all_users_courses($usertwo->id);


### PR DESCRIPTION
- This is an update of PR #231 that was accepted, closed and not merged. Maybe due to last refactoring.
- The feature allow searching of user by custom profil field.
- Lazy loading of settings.
- Site administrator select custom fields allowed for searching users.  
- For more details, please read https://github.com/jpahullo/moodle-tool_mergeusers/pull/231
- In attachement, some scree shot for illustration.
- Administration block
<img width="300" height="520" alt="admin_block" src="https://github.com/user-attachments/assets/23f9c034-fa89-45f8-a2ca-d18b1e7cd72c" />
- Select custom fields allowed for searching
<img width="779" height="503" alt="settings_of_field" src="https://github.com/user-attachments/assets/dce912f7-aa65-4220-8ddd-ae8b87b1101e" />
- Search user by custom profile field allowed in settings 
<img width="641" height="347" alt="search_by_custom_profilefield" src="https://github.com/user-attachments/assets/7debcb9a-14ed-4825-90b8-da507c4623c2" />

@jpahullo , @ndunand : Iet me know if I shouldimprove anything.

Thank you.
