### PR TITLE
 #390 - improvement: gathering::current()/key() declare merge_request…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,25 @@
 If not specified, each change is performed in the version date.
 It means that if version is YYYYMMDDOO, the change was performed on YYYY-MM-DD.
 
+## 2026080600
+
+1. improvement: #390: `gathering::current()`/`key()` now declare `merge_request`/`int` return
+   types instead of `mixed`; the searched-field hint values are now backed by
+   `logger::SEARCHED_FIELD_USERNAME`/`SEARCHED_FIELD_IDNUMBER`/`SEARCHED_FIELD_EMAIL` constants
+   instead of raw string literals. Thanks to @matthewhilton for raising the issue.
+
+### UPGRADING
+
+This version tightens the `gathering` interface's contract: `current()` now must return
+a `merge_request` instance (instead of `mixed`) and `key()` must return an `int` (instead of
+`mixed`). This is a **breaking change** for any custom `gathering` implementation (e.g. a
+bulk/nightly merge process outside the web UI) that does not already return a `merge_request`
+object from `current()`. Before upgrading, review any custom `gathering` in use and adapt its
+`current()` method to construct and return a `merge_request` (setting `fromid`/`toid`, and
+optionally the `fromsearchedfield`/`fromsearchedvalue`/`tosearchedfield`/`tosearchedvalue` hint
+properties), and its `key()` method to return an `int`. Failing to do so will raise a fatal PHP
+error ("Declaration ... must be compatible ...") the next time that gathering class is loaded.
+
 ## 2026080500
 
 1. improvement: #393: merge logs now capture a normalized snapshot of both users' identity

--- a/classes/local/cli/cli_gathering.php
+++ b/classes/local/cli/cli_gathering.php
@@ -29,7 +29,6 @@ defined('MOODLE_INTERNAL') || die();
 defined('CLI_SCRIPT') || die();
 
 use coding_exception;
-use stdClass;
 
 global $CFG;
 require_once($CFG->dirroot . '/lib/clilib.php');
@@ -130,9 +129,10 @@ class cli_gathering implements gathering {
     /**
      * Gets the current pair of users to merge.
      *
-     * @return stdClass object with fromid and toid fields
+     * @return merge_request object with fromid and toid fields, among others.
+     * @see merge_request
      */
-    public function current(): mixed {
+    public function current(): merge_request {
         return $this->current;
     }
 
@@ -141,7 +141,7 @@ class cli_gathering implements gathering {
      *
      * @return int zero-based index value
      */
-    public function key(): mixed {
+    public function key(): int {
         return $this->index;
     }
 }

--- a/classes/local/cli/gathering.php
+++ b/classes/local/cli/gathering.php
@@ -41,4 +41,18 @@ namespace tool_mergeusers\local\cli;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 interface gathering extends \Iterator {
+    /**
+     * Gets the current pair of users to merge.
+     *
+     * @return merge_request object with fromid and toid fields, among others.
+     * @see merge_request
+     */
+    public function current(): merge_request;
+
+    /**
+     * Gets current int zero-based index.
+     *
+     * @return int zero-based index value.
+     */
+    public function key(): int;
 }

--- a/classes/local/cli/merge_request.php
+++ b/classes/local/cli/merge_request.php
@@ -38,4 +38,22 @@ class merge_request {
     public int $fromid;
     /** @var int user.id from the user to keep. */
     public int $toid;
+    /**
+     * @var string|null field name searched for the 'from' user when fromid could not be resolved.
+     * One of \tool_mergeusers\local\logger::SEARCHED_FIELD_USERNAME,
+     * \tool_mergeusers\local\logger::SEARCHED_FIELD_IDNUMBER or
+     * \tool_mergeusers\local\logger::SEARCHED_FIELD_EMAIL; any other value is silently ignored.
+     */
+    public ?string $fromsearchedfield = null;
+    /** @var string|null value searched for the 'from' user when fromid could not be resolved. */
+    public ?string $fromsearchedvalue = null;
+    /**
+     * @var string|null field name searched for the 'to' user when toid could not be resolved.
+     * One of \tool_mergeusers\local\logger::SEARCHED_FIELD_USERNAME,
+     * \tool_mergeusers\local\logger::SEARCHED_FIELD_IDNUMBER or
+     * \tool_mergeusers\local\logger::SEARCHED_FIELD_EMAIL; any other value is silently ignored.
+     */
+    public ?string $tosearchedfield = null;
+    /** @var string|null value searched for the 'to' user when toid could not be resolved. */
+    public ?string $tosearchedvalue = null;
 }

--- a/classes/local/logger.php
+++ b/classes/local/logger.php
@@ -46,13 +46,24 @@ require_once($CFG->libdir . '/clilib.php');
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 final class logger {
+    /** @var string searched-field value for the username field. */
+    public const SEARCHED_FIELD_USERNAME = 'username';
+    /** @var string searched-field value for the idnumber field. */
+    public const SEARCHED_FIELD_IDNUMBER = 'idnumber';
+    /** @var string searched-field value for the email field. */
+    public const SEARCHED_FIELD_EMAIL = 'email';
+
     /**
      * Fields a gathering is allowed to report as the one it searched by when it
      * could not resolve a user. Matches the fields the web UI itself lets an
      * admin search by; excludes 'id' because a not-found search by id is already
      * represented by the existing id + recoverable=false snapshot shape.
      */
-    private const ALLOWED_SEARCH_FIELDS = ['username', 'idnumber', 'email'];
+    private const ALLOWED_SEARCH_FIELDS = [
+        self::SEARCHED_FIELD_USERNAME,
+        self::SEARCHED_FIELD_IDNUMBER,
+        self::SEARCHED_FIELD_EMAIL,
+    ];
 
     /**
      * Adds a merging action log into tool log.

--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -488,7 +488,7 @@ class renderer extends plugin_renderer_base {
             return null;
         }
 
-        foreach (['username', 'idnumber', 'email'] as $field) {
+        foreach ([logger::SEARCHED_FIELD_USERNAME, logger::SEARCHED_FIELD_IDNUMBER, logger::SEARCHED_FIELD_EMAIL] as $field) {
             if (($side[$field] ?? null) !== null) {
                 return [$field, $side[$field]];
             }
@@ -507,9 +507,9 @@ class renderer extends plugin_renderer_base {
      */
     private function searched_field_label(string $field): string {
         $labelkeys = [
-            'username' => 'snapshot_username',
-            'idnumber' => 'snapshot_idnumber',
-            'email' => 'snapshot_email',
+            logger::SEARCHED_FIELD_USERNAME => 'snapshot_username',
+            logger::SEARCHED_FIELD_IDNUMBER => 'snapshot_idnumber',
+            logger::SEARCHED_FIELD_EMAIL => 'snapshot_email',
         ];
 
         return rtrim(get_string($labelkeys[$field], 'tool_mergeusers'), ':');

--- a/tests/gathering_merger_test.php
+++ b/tests/gathering_merger_test.php
@@ -27,6 +27,7 @@ namespace tool_mergeusers;
 
 use advanced_testcase;
 use tool_mergeusers\local\cli\gathering_merger;
+use tool_mergeusers\local\cli\merge_request;
 use tool_mergeusers\local\logger;
 use tool_mergeusers\local\user_merger;
 
@@ -59,12 +60,11 @@ final class gathering_merger_test extends advanced_testcase {
     public function test_merge_propagates_searched_field_hint_from_gathering_action(): void {
         $touser = $this->getDataGenerator()->create_user();
 
-        $action = (object) [
-            'toid' => $touser->id,
-            'fromid' => 0,
-            'fromsearchedfield' => 'username',
-            'fromsearchedvalue' => 'jsmith123',
-        ];
+        $action = new merge_request();
+        $action->toid = $touser->id;
+        $action->fromid = 0;
+        $action->fromsearchedfield = logger::SEARCHED_FIELD_USERNAME;
+        $action->fromsearchedvalue = 'jsmith123';
 
         $mut = new gathering_merger(new user_merger());
         $mut->merge(new in_memory_gathering([$action]));
@@ -90,12 +90,11 @@ final class gathering_merger_test extends advanced_testcase {
         $touser = $this->getDataGenerator()->create_user();
         $fromuser = $this->getDataGenerator()->create_user();
 
-        $action = (object) [
-            'toid' => $touser->id,
-            'fromid' => $fromuser->id,
-            'fromsearchedfield' => 'username',
-            'fromsearchedvalue' => 'oldusername',
-        ];
+        $action = new merge_request();
+        $action->toid = $touser->id;
+        $action->fromid = $fromuser->id;
+        $action->fromsearchedfield = logger::SEARCHED_FIELD_USERNAME;
+        $action->fromsearchedvalue = 'oldusername';
 
         $mut = new gathering_merger(new user_merger());
         $mut->merge(new in_memory_gathering([$action]));
@@ -119,14 +118,13 @@ final class gathering_merger_test extends advanced_testcase {
      * @group tool_mergeusers_cli
      */
     public function test_merge_propagates_hints_for_both_sides_when_neither_is_resolved(): void {
-        $action = (object) [
-            'toid' => 0,
-            'fromid' => 0,
-            'tosearchedfield' => 'username',
-            'tosearchedvalue' => 'tokeep123',
-            'fromsearchedfield' => 'username',
-            'fromsearchedvalue' => 'toremove123',
-        ];
+        $action = new merge_request();
+        $action->toid = 0;
+        $action->fromid = 0;
+        $action->tosearchedfield = logger::SEARCHED_FIELD_USERNAME;
+        $action->tosearchedvalue = 'tokeep123';
+        $action->fromsearchedfield = logger::SEARCHED_FIELD_USERNAME;
+        $action->fromsearchedvalue = 'toremove123';
 
         $mut = new gathering_merger(new user_merger());
         $mut->merge(new in_memory_gathering([$action]));
@@ -152,10 +150,9 @@ final class gathering_merger_test extends advanced_testcase {
         $usertoremove = $this->getDataGenerator()->create_user();
         $usertokeep = $this->getDataGenerator()->create_user();
 
-        $action = (object) [
-            'toid' => $usertokeep->id,
-            'fromid' => $usertoremove->id,
-        ];
+        $action = new merge_request();
+        $action->toid = $usertokeep->id;
+        $action->fromid = $usertoremove->id;
 
         $mut = new gathering_merger(new user_merger());
         $mut->merge(new in_memory_gathering([$action]));
@@ -188,7 +185,7 @@ class in_memory_gathering implements \tool_mergeusers\local\cli\gathering {
     /**
      * Constructor.
      *
-     * @param array $actions list of stdClass actions with at least toid/fromid.
+     * @param array $actions list of merge_request actions with at least toid/fromid.
      */
     public function __construct(array $actions) {
         $this->actions = $actions;
@@ -213,18 +210,18 @@ class in_memory_gathering implements \tool_mergeusers\local\cli\gathering {
     /**
      * Gets the current action.
      *
-     * @return mixed
+     * @return merge_request
      */
-    public function current(): mixed {
+    public function current(): merge_request {
         return $this->actions[$this->position];
     }
 
     /**
      * Gets the current position.
      *
-     * @return mixed
+     * @return int
      */
-    public function key(): mixed {
+    public function key(): int {
         return $this->position;
     }
 

--- a/tests/logger_test.php
+++ b/tests/logger_test.php
@@ -154,7 +154,7 @@ final class logger_test extends advanced_testcase {
      * @group tool_mergeusers_logger
      */
     public function test_notfound_snapshot_reuses_matching_field_for_allowed_searched_field(): void {
-        $snapshot = logger::notfound_snapshot('email', 'x@example.com');
+        $snapshot = logger::notfound_snapshot(logger::SEARCHED_FIELD_EMAIL, 'x@example.com');
 
         $this->assertTrue($snapshot->notfound);
         $this->assertFalse($snapshot->recoverable);
@@ -199,7 +199,7 @@ final class logger_test extends advanced_testcase {
      * @group tool_mergeusers_logger
      */
     public function test_capture_user_snapshot_propagates_hint_when_not_found(): void {
-        $snapshot = logger::capture_user_snapshot(0, ['field' => 'username', 'value' => 'jsmith123']);
+        $snapshot = logger::capture_user_snapshot(0, ['field' => logger::SEARCHED_FIELD_USERNAME, 'value' => 'jsmith123']);
         $this->assertTrue($snapshot->notfound);
         $this->assertSame('jsmith123', $snapshot->username);
 
@@ -220,7 +220,10 @@ final class logger_test extends advanced_testcase {
     public function test_capture_user_snapshot_hint_prevails_for_a_resolved_user(): void {
         $user = $this->getDataGenerator()->create_user(['idnumber' => 'ID001']);
 
-        $snapshot = logger::capture_user_snapshot($user->id, ['field' => 'username', 'value' => 'oldusername']);
+        $snapshot = logger::capture_user_snapshot(
+            $user->id,
+            ['field' => logger::SEARCHED_FIELD_USERNAME, 'value' => 'oldusername'],
+        );
 
         $this->assertFalse($snapshot->notfound);
         $this->assertTrue($snapshot->recoverable);
@@ -256,7 +259,10 @@ final class logger_test extends advanced_testcase {
      * @group tool_mergeusers_logger
      */
     public function test_capture_user_snapshot_hint_prevails_for_unrecoverable_id(): void {
-        $snapshot = logger::capture_user_snapshot(999999, ['field' => 'email', 'value' => 'old@example.com']);
+        $snapshot = logger::capture_user_snapshot(
+            999999,
+            ['field' => logger::SEARCHED_FIELD_EMAIL, 'value' => 'old@example.com'],
+        );
 
         $this->assertFalse($snapshot->notfound);
         $this->assertFalse($snapshot->recoverable);
@@ -285,7 +291,7 @@ final class logger_test extends advanced_testcase {
             ['Could not resolve username.'],
             null,
             null,
-            ['field' => 'username', 'value' => 'jsmith123'],
+            ['field' => logger::SEARCHED_FIELD_USERNAME, 'value' => 'jsmith123'],
         );
         $stored = $mut->detail_from($logid);
         $this->assertSame('jsmith123', $stored->log->user_snapshots->from_user->username);

--- a/tests/merge_user_display_test.php
+++ b/tests/merge_user_display_test.php
@@ -73,7 +73,7 @@ final class merge_user_display_test extends advanced_testcase {
      * @group tool_mergeusers_renderer
      */
     public function test_from_snapshot_notfound_with_searched_field_hint(): void {
-        $display = merge_user_display::from_snapshot(logger::notfound_snapshot('idnumber', 'ID999'));
+        $display = merge_user_display::from_snapshot(logger::notfound_snapshot(logger::SEARCHED_FIELD_IDNUMBER, 'ID999'));
 
         $this->assertTrue($display->notfound);
         $this->assertSame('ID999', $display->idnumber);

--- a/tests/renderer_test.php
+++ b/tests/renderer_test.php
@@ -26,6 +26,7 @@
 namespace tool_mergeusers;
 
 use advanced_testcase;
+use tool_mergeusers\local\logger;
 use tool_mergeusers\output\renderer;
 use tool_mergeusers_renderer;
 
@@ -167,7 +168,7 @@ final class renderer_test extends advanced_testcase {
         $touser = $this->getDataGenerator()->create_user();
         $fromuser = $this->getDataGenerator()->create_user();
 
-        $logger = new \tool_mergeusers\local\logger();
+        $logger = new logger();
         $logid = $logger->log($touser->id, $fromuser->id, true, ['Some action.']);
         $stored = $logger->detail_from($logid);
 
@@ -274,7 +275,7 @@ final class renderer_test extends advanced_testcase {
 
         $touser = $this->getDataGenerator()->create_user();
 
-        $logger = new \tool_mergeusers\local\logger();
+        $logger = new logger();
         $logid = $logger->log($touser->id, 0, false, ['Could not resolve username.']);
         $stored = $logger->detail_from($logid);
 
@@ -300,7 +301,7 @@ final class renderer_test extends advanced_testcase {
 
         $touser = $this->getDataGenerator()->create_user();
 
-        $logger = new \tool_mergeusers\local\logger();
+        $logger = new logger();
         $logid = $logger->log(
             $touser->id,
             0,
@@ -308,7 +309,7 @@ final class renderer_test extends advanced_testcase {
             ['Could not resolve email.'],
             null,
             null,
-            ['field' => 'email', 'value' => 'missing@example.com'],
+            ['field' => logger::SEARCHED_FIELD_EMAIL, 'value' => 'missing@example.com'],
         );
         $stored = $logger->detail_from($logid);
 
@@ -341,7 +342,7 @@ final class renderer_test extends advanced_testcase {
 
         $touser = $this->getDataGenerator()->create_user();
 
-        $logger = new \tool_mergeusers\local\logger();
+        $logger = new logger();
         $logger->log($touser->id, 0, false, ['Could not resolve username.']);
 
         $logs = $logger->get();
@@ -367,7 +368,7 @@ final class renderer_test extends advanced_testcase {
 
         $touser = $this->getDataGenerator()->create_user();
 
-        $logger = new \tool_mergeusers\local\logger();
+        $logger = new logger();
         $logger->log(
             $touser->id,
             0,
@@ -375,7 +376,7 @@ final class renderer_test extends advanced_testcase {
             ['Could not resolve username.'],
             null,
             null,
-            ['field' => 'username', 'value' => 'jsmith123'],
+            ['field' => logger::SEARCHED_FIELD_USERNAME, 'value' => 'jsmith123'],
         );
 
         $output = $this->get_renderer()->logs_page($logger->get());
@@ -406,7 +407,7 @@ final class renderer_test extends advanced_testcase {
         // username, which would make it overlap with the username assertions below.
         $user = $this->getDataGenerator()->create_user(['username' => 'newusername', 'email' => 'person@example.com']);
 
-        $logger = new \tool_mergeusers\local\logger();
+        $logger = new logger();
         $logid = $logger->log(
             $user->id,
             $user->id,
@@ -414,7 +415,7 @@ final class renderer_test extends advanced_testcase {
             ['Renamed username in place.'],
             null,
             null,
-            ['field' => 'username', 'value' => 'oldusername'],
+            ['field' => logger::SEARCHED_FIELD_USERNAME, 'value' => 'oldusername'],
         );
         $stored = $logger->detail_from($logid);
 

--- a/tests/user_merger_test.php
+++ b/tests/user_merger_test.php
@@ -19,6 +19,7 @@ namespace tool_mergeusers;
 use advanced_testcase;
 use dml_exception;
 use moodle_exception;
+use tool_mergeusers\local\logger;
 use tool_mergeusers\local\user_merger;
 
 /**
@@ -177,9 +178,15 @@ final class user_merger_test extends advanced_testcase {
         $usertokeep = $this->getDataGenerator()->create_user();
 
         $mut = new user_merger();
-        [, , $logidwithhint] = $mut->merge($usertokeep->id, 0, null, null, ['field' => 'username', 'value' => 'jsmith123']);
+        [, , $logidwithhint] = $mut->merge(
+            $usertokeep->id,
+            0,
+            null,
+            null,
+            ['field' => logger::SEARCHED_FIELD_USERNAME, 'value' => 'jsmith123'],
+        );
 
-        $logger = new \tool_mergeusers\local\logger();
+        $logger = new logger();
         $storedwithhint = $logger->detail_from($logidwithhint);
         $this->assertSame('jsmith123', $storedwithhint->log->user_snapshots->from_user->username);
 
@@ -206,14 +213,14 @@ final class user_merger_test extends advanced_testcase {
             0,
             0,
             null,
-            ['field' => 'username', 'value' => 'tokeep123'],
-            ['field' => 'username', 'value' => 'toremove123'],
+            ['field' => logger::SEARCHED_FIELD_USERNAME, 'value' => 'tokeep123'],
+            ['field' => logger::SEARCHED_FIELD_USERNAME, 'value' => 'toremove123'],
         );
 
         $this->assertFalse($success);
         $this->assertStringNotContainsString(get_string('errorsameuser', 'tool_mergeusers'), implode(' ', $log));
 
-        $logger = new \tool_mergeusers\local\logger();
+        $logger = new logger();
         $stored = $logger->detail_from($logid);
         $this->assertSame('tokeep123', $stored->log->user_snapshots->to_user->username);
         $this->assertSame('toremove123', $stored->log->user_snapshots->from_user->username);

--- a/version.php
+++ b/version.php
@@ -30,8 +30,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2026080500;
-$plugin->release = '(2026080500: Focus on stability and extensibility)';
+$plugin->version = 2026080600;
+$plugin->release = '(2026080600: Focus on stability and extensibility)';
 $plugin->requires = 2024100700; // Moodle 4.5+, https://moodledev.io/general/releases#moodle-45-lts.
 $plugin->component = 'tool_mergeusers';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
…/int return types instead of mixed

Applies the upstream PR #391 idea (typed Iterator return types), adapted to this fork's cli_gathering/merge_request shape instead of stdClass, which would have broken at runtime. The gathering interface now redeclares the contract explicitly, and searched-field hint values are backed by new logger::SEARCHED_FIELD_USERNAME/SEARCHED_FIELD_IDNUMBER/SEARCHED_FIELD_EMAIL constants instead of raw string literals.

Thanks to @matthewhilton for raising the issue.

Bumps version to 2026080600 (2026080500 already tagged and released).