### PR TITLE
 #420 - chore: enforce phpcs as a hard CI gate, document the moodle-e…

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -14,3 +14,4 @@ jobs:
       disable_release: true
       disable_behat: true
       disable_version_bump_check: true
+      codechecker_max_warnings: 0

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 .idea
 phpunit.xml
+.bin

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,10 +125,51 @@ To support a new table or plugin without touching core merge logic:
   superglobals), check `require_login()` / `require_capability()` /
   `require_sesskey()` on state-changing requests, and escape all output
   (`s()`, `format_string()`, `format_text()`).
-- CI does **not** run `phpcs`, `phpdoc` or `grunt` checks automatically
-  (they are explicitly disabled in the CI workflow) — run them locally
-  before proposing a change: `make phpcs` / `make phpcbf` (these ignore
-  `tests/`).
+- CI (`.github/workflows/moodle-ci.yml`) runs `phpcs`/`phpdoc` via
+  `moodle-plugin-ci`'s `codechecker` step, against the whole plugin
+  (including `tests/`), using the base `moodle` standard. It is a hard gate:
+  `codechecker_max_warnings: 0` means any warning, not just an error, fails
+  the build. `grunt`, `behat`, the release job and the version-bump check are
+  explicitly disabled (`disable_*: true`); `phpunit` runs normally.
+- **Before proposing any change, run the checks locally and make sure they
+  are clean — the GitHub Actions build must always stay green.**
+  - **`make ci-local`** is the primary/authoritative check: it runs the real
+    `moodle-plugin-ci` tool (`.bin/moodle-plugin-ci.phar`, gitignored,
+    downloaded on demand — see below) against every step
+    `.github/workflows/moodle-ci.yml` currently enables:
+    `phplint`, `codechecker --max-warnings=0`, `validate`, `savepoints`,
+    `mustache`, `phpdoc` (`grunt`/`behat`/release/version-bump-check are
+    disabled there, so have no local equivalent). This is the *same tool*
+    CI runs, not a separate reimplementation of it (see the warning about
+    `local_codechecker` below). Run a single step on its own with `make
+    ci-<step>` (e.g. `make ci-codechecker`). `phpunit` is intentionally not
+    part of this group — use `make pass-tests` for that, it needs no
+    `moodle-plugin-ci` at all.
+  - `.bin/moodle-plugin-ci.phar` tracks the latest GitHub release of
+    `moodlehq/moodle-plugin-ci`, refreshed at most once a day: any `ci-*`
+    target depends on `ensure-moodle-plugin-ci`, which is a no-op if the
+    phar's mtime is already today, or otherwise checks GitHub and downloads
+    only if a newer version exists (touching the phar either way, so it
+    won't check again until tomorrow). Run `make update-moodle-plugin-ci`
+    directly to force an immediate re-check/upgrade — e.g. right after a
+    `moodle-plugin-ci` release you know fixes something relevant, without
+    waiting for the daily window.
+  - Use `make phpcbf` to auto-fix coding-standard violations `make
+    ci-codechecker` reports — it runs `local_codechecker`'s bundled
+    `phpcbf`, since `moodle-plugin-ci` has no auto-fix command of its own.
+
+  **Don't use `local_codechecker`'s own phpcs check (`--standard=moodle` or
+  `moodle-extra`) to decide whether CI will pass — only `make ci-local`/
+  `make ci-codechecker` can answer that.** CI never runs the stricter
+  `moodle-extra` standard at all, and `local_codechecker`'s bundled
+  `moodle-cs`/`phpcsextra` version is a separate Moodle plugin with its own,
+  slower release cadence, so it can lag behind what `moodle-plugin-ci` (and
+  therefore CI) actually installs — specific sniffs can behave differently
+  release to release. This bit once: `Universal.OOStructures.
+  AlphabeticExtendsImplements` (interface order in a `class ... implements`
+  statement) sorted by a different key in an older `local_codechecker`
+  install vs. a current `moodle-plugin-ci.phar`, each insisting the
+  *other*'s order was wrong.
 
 ## Testing requirements
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,32 @@
-# This file assumes exists a .env with the necessary environment variables.
+# Coexistence between running make from the host and from a shell already inside the
+# dev container: /.dockerenv only exists inside a real Docker container, so it wins
+# over container_name - a .env checked in (or exported) with container_name set
+# still works unwrapped from inside the container, no need to unset/comment it out
+# to switch between the two. Only outside a container, with container_name defined,
+# do targets wrap with "docker exec -it $(container_name)"; otherwise php runs bare.
+in-container := $(wildcard /.dockerenv)
 current-dir := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
+# Absolute path to this plugin, and to the Moodle dirroot it lives under, both
+# derived from where this Makefile itself is - never hardcoded - so this works the
+# same whether the dirroot is .../admin/tool/mergeusers (Moodle up to 4.x) or
+# .../public/admin/tool/mergeusers (Moodle 5.x's "public" docroot), and passed as-is
+# to $(docker)/$(docker-with-xdebug): this assumes the dev container bind-mounts the
+# codebase at the same absolute path as the host, which most docker-compose Moodle
+# setups do.
+plugin-dir := $(patsubst %/,%,$(current-dir))
+moodle-dir := $(patsubst %/admin/tool/mergeusers,%,$(plugin-dir))
+
+# vendor/ (composer deps, incl. phpunit) sits inside the dirroot on Moodle <=4.x, but
+# one level above it - alongside "public/" - on Moodle 5.x's split docroot layout.
+# Detected once, on the host, rather than assumed.
+ifneq ($(wildcard $(moodle-dir)/vendor/bin/phpunit),)
+vendor-dir := $(moodle-dir)/vendor
+else
+vendor-dir := $(abspath $(moodle-dir)/../vendor)
+endif
+
 # By default, only "container_name=name_of_container" is required. See below.
-# If this file does not exists during development, the make command fails.
 # This file should define at least:
 # ===========================
 # container_name=name_of_container
@@ -12,21 +36,33 @@ current-dir := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 # On my setup, both "start" and "stop" commands must be placed without colon nor double colons
 # to work properly.
 # I decided to proceed this way, since I work with custom shell scripts over the moodle-docker setup.
-include $(current-dir).env
+-include $(current-dir).env
 
-# This file assumes dockerized development environment and moodle-local_codechecker plugin installed.
-# However, you can redefine these variables into the .env file to meet your needs.
-ifndef docker:
+# Redefine any of docker/docker-with-xdebug/phpcbf/moodle-plugin-ci in .env to
+# override. See the comment at the top of this file for what decides docker/
+# docker-with-xdebug otherwise.
+ifneq ($(in-container),)
+docker :=
+docker-with-xdebug :=
+else
+ifdef container_name
 docker := docker exec -it $(container_name)
-endif
-ifndef docker-with-xdebug:
 docker-with-xdebug := docker exec -e XDEBUG_SESSION=1 -it $(container_name)
+else
+docker :=
+docker-with-xdebug :=
 endif
-ifndef phpcs:
-phpcs := $(docker) php local/codechecker/vendor/bin/phpcs
 endif
-ifndef phpcbf:
-phpcbf := $(docker) php local/codechecker/vendor/bin/phpcbf
+ifndef phpcbf
+phpcbf := $(docker) php $(moodle-dir)/local/codechecker/vendor/bin/phpcbf
+endif
+
+# Path to the locally-managed moodle-plugin-ci.phar, kept in sync with the latest
+# GitHub release via ensure-moodle-plugin-ci/update-moodle-plugin-ci below. .bin/ is
+# gitignored: this is downloaded, never committed.
+moodle-plugin-ci-phar := $(current-dir).bin/moodle-plugin-ci.phar
+ifndef moodle-plugin-ci
+moodle-plugin-ci := $(docker) php $(plugin-dir)/.bin/moodle-plugin-ci.phar
 endif
 
 .PHONY: start
@@ -37,60 +73,133 @@ start:
 stop:
 	bash -c "$(stop)"
 
+# Pass XDEBUG=1 to run under xdebug instead (replaces the old pass-tests-with-xdebug
+# target - both spellings still work, the latter just forwards here).
 .PHONY: pass-tests
 pass-tests: options =
+pass-tests: docker-cmd = $(if $(XDEBUG),$(docker-with-xdebug),$(docker))
 pass-tests:
-	$(docker) php vendor/bin/phpunit -c admin/tool/mergeusers --testdox $(options)
+	$(docker-cmd) php $(vendor-dir)/bin/phpunit -c $(plugin-dir) --testdox $(options)
 
 .PHONY: pass-tests-with-xdebug
+pass-tests-with-xdebug: options =
 pass-tests-with-xdebug:
-	$(docker-with-xdebug) php vendor/bin/phpunit -c admin/tool/mergeusers --testdox $(options)
+	$(MAKE) -f $(current-dir)Makefile pass-tests XDEBUG=1 options='$(options)'
 
 .PHONY: build-phpunit-xml
 build-phpunit-xml:
-	$(docker)  php admin/tool/phpunit/cli/util.php --buildcomponentconfig
+	$(docker)  php $(moodle-dir)/admin/tool/phpunit/cli/util.php --buildcomponentconfig
 
 .PHONY: init-phpunit
 init-phpunit:
-	$(docker) php admin/tool/phpunit/cli/init.php
+	$(docker) php $(moodle-dir)/admin/tool/phpunit/cli/init.php
 
-.PHONY: phpcs
-phpcs: options = admin/tool/mergeusers --ignore=tests/
-phpcs:
-	$(phpcs) $(options)
-
-.PHONY: phpcs
-phpcs-for-staged-files:
-	$(phpcs) $$( echo $$(git diff --cached --name-only | xargs -I {} -n 1 echo 'admin/tool/mergeusers/{}')) --ignore=tests/
-
-
-.PHONY: phpcs-list-sniffs
-phpcs-list-sniffs: options = -e
-phpcs-list-sniffs:
-	$(phpcs) $(options)
-
+# No phpcs target: ci-codechecker below runs the same check moodle-ci.yml enforces
+# in CI, via the real moodle-plugin-ci tool - it superseded this. phpcbf stays: there
+# is no moodle-plugin-ci equivalent for auto-fixing.
 .PHONY: phpcbf
-phpcbf: options = admin/tool/mergeusers
+phpcbf: options = $(plugin-dir)
 phpcbf:
 	$(phpcbf) $(options)
 
 .PHONY: phpcbf-for-staged-files
 phpcbf-for-staged-files:
-	$(phpcbf) $$( echo $$(git diff --cached --name-only | xargs -I {} -n 1 echo 'admin/tool/mergeusers/{}')) --ignore=tests/
+	$(phpcbf) $$( echo $$(git diff --cached --name-only | xargs -I {} -n 1 echo '$(plugin-dir)/{}')) --ignore=tests/
 
+# Makes sure .bin/moodle-plugin-ci.phar exists and was checked against the latest
+# GitHub release today; does nothing (no network call) if it was already checked
+# today, regardless of whether that check found a new version. Only needs curl/php,
+# no Moodle bootstrap, so it always runs bare (no $(docker)), even when invoked from
+# the host - there is nothing container-specific about downloading a phar.
+.PHONY: ensure-moodle-plugin-ci
+ensure-moodle-plugin-ci:
+	@if [ -f "$(moodle-plugin-ci-phar)" ] && \
+	    [ "$$(date -r "$(moodle-plugin-ci-phar)" +%Y-%m-%d 2>/dev/null)" = "$$(date +%Y-%m-%d)" ]; then \
+		echo "moodle-plugin-ci.phar already checked today."; \
+	else \
+		$(MAKE) -f $(current-dir)Makefile update-moodle-plugin-ci; \
+	fi
+
+# Unconditionally checks GitHub for the latest moodle-plugin-ci release (regardless
+# of when it was last checked) and downloads it if we don't already have that exact
+# version. Always touches the phar afterwards, so ensure-moodle-plugin-ci won't
+# check again until tomorrow. Use this directly when you need the fix in a release
+# that just shipped, without waiting for the daily check.
+.PHONY: update-moodle-plugin-ci
+update-moodle-plugin-ci:
+	@set -eu; \
+	mkdir -p "$$(dirname "$(moodle-plugin-ci-phar)")"; \
+	latest=$$(curl -fsSL https://api.github.com/repos/moodlehq/moodle-plugin-ci/releases/latest \
+		| grep -m1 '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/'); \
+	if [ -z "$$latest" ]; then \
+		echo "Could not determine the latest moodle-plugin-ci release." >&2; \
+		exit 1; \
+	fi; \
+	current=""; \
+	if [ -x "$(moodle-plugin-ci-phar)" ]; then \
+		current=$$(php "$(moodle-plugin-ci-phar)" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1); \
+	fi; \
+	if [ "$$current" = "$$latest" ]; then \
+		echo "moodle-plugin-ci.phar is already the latest ($$latest)."; \
+		touch "$(moodle-plugin-ci-phar)"; \
+	else \
+		echo "Downloading moodle-plugin-ci.phar $$latest (had: $${current:-none})..."; \
+		curl -fsSL -o "$(moodle-plugin-ci-phar)" \
+			"https://github.com/moodlehq/moodle-plugin-ci/releases/download/$$latest/moodle-plugin-ci.phar"; \
+		chmod +x "$(moodle-plugin-ci-phar)"; \
+		echo "Installed moodle-plugin-ci.phar $$latest."; \
+	fi
+
+# Individual moodle-plugin-ci checks, matching the steps enabled in
+# .github/workflows/moodle-ci.yml (grunt/behat/release/version-bump-check are
+# disabled there, so have no equivalent here). codechecker/phplint/savepoints run
+# standalone; validate/mustache/phpdoc need a Moodle root, given explicitly via
+# --moodle=$(moodle-dir) rather than relying on cwd.
+.PHONY: ci-codechecker
+ci-codechecker: ensure-moodle-plugin-ci
+	$(moodle-plugin-ci) codechecker --max-warnings=0 $(plugin-dir)
+
+.PHONY: ci-phplint
+ci-phplint: ensure-moodle-plugin-ci
+	$(moodle-plugin-ci) phplint $(plugin-dir)
+
+.PHONY: ci-savepoints
+ci-savepoints: ensure-moodle-plugin-ci
+	$(moodle-plugin-ci) savepoints $(plugin-dir)
+
+.PHONY: ci-validate
+ci-validate: ensure-moodle-plugin-ci
+	$(moodle-plugin-ci) validate --moodle=$(moodle-dir) $(plugin-dir)
+
+.PHONY: ci-mustache
+ci-mustache: ensure-moodle-plugin-ci
+	$(moodle-plugin-ci) mustache --moodle=$(moodle-dir) $(plugin-dir)
+
+.PHONY: ci-phpdoc
+ci-phpdoc: ensure-moodle-plugin-ci
+	$(moodle-plugin-ci) phpdoc --moodle=$(moodle-dir) $(plugin-dir)
+
+# Runs every local-equivalent check moodle-ci.yml enables, in the same spirit as the
+# GitHub Actions job. phpunit is deliberately not included here - use pass-tests for
+# that, which runs $(vendor-dir)/bin/phpunit directly: moodle-plugin-ci's own phpunit
+# command hardcodes "<moodle-dir>/vendor/bin/phpunit", which does not account for
+# Moodle 5.x's split docroot (see $(vendor-dir) above) and would fail here.
+.PHONY: ci-local
+ci-local: ci-phplint ci-codechecker ci-validate ci-savepoints ci-mustache ci-phpdoc
+	@echo "All local CI-equivalent checks passed."
 
 .PHONY: purgecaches
 purgecaches:
-	$(docker) php admin/cli/purge_caches.php
+	$(docker) php $(moodle-dir)/admin/cli/purge_caches.php
 
 .PHONY: upgrade
 upgrade:
-	$(docker) php admin/cli/upgrade.php --non-interactive
+	$(docker) php $(moodle-dir)/admin/cli/upgrade.php --non-interactive
 
 .PHONY: run-cli-merge
 run-cli-merge:
-	$(docker) php admin/tool/mergeusers/cli/climerger.php
+	$(docker) php $(plugin-dir)/cli/climerger.php
 
 .PHONY: list-user-fields
 list-user-fields:
-	$(docker) php admin/tool/mergeusers/cli/listuserfields.php
+	$(docker) php $(plugin-dir)/cli/listuserfields.php

--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -215,7 +215,7 @@ class renderer extends plugin_renderer_base {
      *
      * @param object $to             stdClass with at least id and username fields (current/dynamic data).
      * @param object $from           stdClass with at least id and username fields (current/dynamic data).
-     * @param string $status         status of the merging process.
+     * @param string|null $status    status of the merging process.
      * @param array|stdClass $data   logs of actions done if success, or list of errors on failure.
      * @param int $logid             id of the record with the whole detail of this merging action.
      * @param int|null $timecreated  timestamp when merge was queued/initiated.

--- a/tests/gathering_merger_test.php
+++ b/tests/gathering_merger_test.php
@@ -31,6 +31,8 @@ use tool_mergeusers\local\cli\merge_request;
 use tool_mergeusers\local\logger;
 use tool_mergeusers\local\user_merger;
 
+defined('MOODLE_INTERNAL') || die();
+
 /**
  * Tests for tool_mergeusers\local\cli\gathering_merger.
  *


### PR DESCRIPTION
…xtra policy

- .github/workflows/moodle-ci.yml: set codechecker_max_warnings: 0. phpcs/ phpdoc were already enabled by default in the reusable workflow (no disable_phpcs/disable_phpdoc flag here), but warnings never failed the build; now any warning does too, same as an error.
- AGENTS.md: the "CI does not run phpcs" note was stale - phpcs/phpdoc have actually been enabled since 690a5cf. Replaced it with what CI really runs (moodle standard, whole plugin, now a hard gate) and the local-before-push policy: `--standard=moodle` must stay clean (mirrors CI exactly), and `--standard=moodle-extra` a step further, which CI doesn't check but this codebase is kept clean against too.
- classes/privacy/provider.php, tests/gathering_merger_test.php: the only two moodle-extra warnings found when auditing the whole plugin against it. provider.php's implements order was already alphabetical by fully- qualified name, but Universal.OOStructures.AlphabeticExtendsImplements sorts by the interface's last name segment only (and its own error message mislabels which order is "Expected" vs "Found" - a phpcsextra bug); reordered to what the sniff actually wants while keeping the multi-line formatting phpcbf would otherwise collapse into one long line. gathering_merger_test.php defines a second top-level class (in_memory_gathering) and was missing the MOODLE_INTERNAL guard that multi-class test files in this plugin already carry (e.g. renderer_test.php).