### PR TITLE
#395 - choice_answers and survey_answers compound indexes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,33 @@
 If not specified, each change is performed in the version date.
 It means that if version is YYYYMMDDOO, the change was performed on YYYY-MM-DD.
 
+## 2026081301
+
+1. fix: #395: a merge could leave a `mod_choice` user with two answers for the
+   same choice when it does not allow multiple answers, or with an
+   unintentionally deduplicated answer when it does - `choice_answers` had no
+   real database index, but `mod_choice`'s own PHP code assumes one, and would
+   otherwise silently report an arbitrary one of the duplicate answers (plus a
+   `debugging()` notice) instead of the merged user's real answer when reading
+   their activity report. A new `choice_answers_table_merger` now resolves
+   conflicts using each choice's own `allowmultiple` setting: at most one
+   answer per user when it is off, one answer per user per option when it is
+   on. `generic_table_merger` gained an overridable `build_group_key()` method
+   to support this.
+2. fix: #395: `survey_answers` (Moodle 4.5's `mod_survey`, still supported by
+   this plugin) is now a compound index too: a merge where both users had
+   answered the same survey question would otherwise leave the merged user
+   with two answers to it, silently double-counting them in survey results
+   reports.
+3. `lesson_attempts` was also evaluated for #395, but intentionally left out
+   of this fix: no crash or real database constraint was found, only a
+   cosmetic duplicate "try" number in `lesson_report.php` when both merged
+   users had attempted the same lesson - fixing that losslessly would need a
+   dedicated renumbering table_merger, akin to `quiz_attempts_table_merger`,
+   which is a large enough change to warrant its own future issue.
+
+   Thanks to @charbusch for raising the issue.
+
 ## 2026081300
 
 1. fix: #429: the results page after a synchronous web merge (no ad-hoc task queued)

--- a/classes/local/default_db_config.php
+++ b/classes/local/default_db_config.php
@@ -27,6 +27,7 @@ namespace tool_mergeusers\local;
 
 use tool_mergeusers\local\cli\cli_gathering;
 use tool_mergeusers\local\merger\assign_submission_table_merger;
+use tool_mergeusers\local\merger\choice_answers_table_merger;
 use tool_mergeusers\local\merger\generic_table_merger;
 use tool_mergeusers\local\merger\quiz_attempts_table_merger;
 use tool_mergeusers\local\merger\grade_grades_table_merger;
@@ -100,6 +101,19 @@ class default_db_config {
                 // Type of index: unique; type of matching: by foreign key.
                 'userfield' => ['userid'],
                 'otherfields' => ['cmid', 'courseid'],
+            ],
+            'choice_answers' => [
+                // No real DB index (see mod/choice/db/install.xml); PHP business logic
+                // assumes uniqueness per (choiceid, optionid) when the choice allows
+                // multiple answers, or per choiceid alone otherwise -
+                // mod/choice/lib.php's choice_user_outline() reads it with a singular
+                // get_record(), which - with more than one matching row - silently
+                // returns an arbitrary one of the answers instead of the merged user's
+                // real one (plus a debugging() notice).
+                // Handled by choice_answers_table_merger, which decides the actual
+                // grouping key per record from the choice's own 'allowmultiple' setting.
+                'userfield' => ['userid'],
+                'otherfields' => ['choiceid', 'optionid'],
             ],
             'cohort_members' => [
                 // For index 'cohortid-userid'.
@@ -440,6 +454,7 @@ class default_db_config {
         // The 'default' is applied when no specific table_merger is specified.
         'tablemergers' => [
             'default' => generic_table_merger::class,
+            'choice_answers' => choice_answers_table_merger::class,
             'quiz_attempts' => quiz_attempts_table_merger::class,
             'assign_submission' => assign_submission_table_merger::class,
             'grade_grades' => grade_grades_table_merger::class,

--- a/classes/local/default_db_config.php
+++ b/classes/local/default_db_config.php
@@ -192,6 +192,16 @@ class default_db_config {
                 'userfield' => ['userid'],
                 'otherfields' => ['attempt', 'quiz'],
             ],
+            'survey_answers' => [
+                // No real DB index (see mod/survey/db/install.xml; mod_survey was removed
+                // from Moodle core after 4.5, but this plugin still supports 4.5). PHP
+                // business logic assumes at most one answer per user per (survey,
+                // question); without this, a merge where both users answered the same
+                // question would leave the merged user with two answers, silently
+                // double-counting them in survey results reports.
+                'userfield' => ['userid'],
+                'otherfields' => ['survey', 'question'],
+            ],
             'tool_policy_acceptances' => [
                 // For index 'mdl_toolpoliacce_poluse_uix'.
                 // Type of index: unique; type of matching: by foreign key.

--- a/classes/local/merger/choice_answers_table_merger.php
+++ b/classes/local/merger/choice_answers_table_merger.php
@@ -70,6 +70,11 @@ class choice_answers_table_merger extends generic_table_merger {
      * Generates an SQL query that also fetches the owning choice's 'allowmultiple' value,
      * needed by self::build_group_key() to decide the real uniqueness key per record.
      *
+     * Uses a LEFT JOIN, not an INNER JOIN: Moodle does not enforce this foreign key at the
+     * database level, so a choice_answers row could in principle point to a choice that no
+     * longer exists. An INNER JOIN would silently exclude such orphaned rows from conflict
+     * detection entirely, defeating the purpose of this merger for them.
+     *
      * @param array $data Array containing the table name, `fromid`, and `toid` for the merging operation.
      * @param string $userfield The field name in the table that refers to the user ID.
      * @param string $otherfieldsstr A string representing the other fields in the compound index, separated by commas.
@@ -78,7 +83,7 @@ class choice_answers_table_merger extends generic_table_merger {
     protected function build_sql_query(array $data, string $userfield, string $otherfieldsstr): array {
         $sql = 'SELECT ca.id, ca.' . $userfield . ', ' . $otherfieldsstr . ', c.allowmultiple' .
             ' FROM {' . $data['tableName'] . '} ca' .
-            ' JOIN {choice} c ON c.id = ca.choiceid' .
+            ' LEFT JOIN {choice} c ON c.id = ca.choiceid' .
             ' WHERE ca.' . $userfield . ' IN ( ?, ?)';
 
         return [$sql, [$data['fromid'], $data['toid']]];
@@ -88,12 +93,16 @@ class choice_answers_table_merger extends generic_table_merger {
      * Builds the grouping key for a choice_answers record: choiceid alone when the owning
      * choice does not allow multiple answers per user, or (choiceid, optionid) when it does.
      *
+     * A missing (null) 'allowmultiple' - an orphaned row whose choice no longer exists, per
+     * the LEFT JOIN in self::build_sql_query() - is treated the same as 0 (single-select),
+     * the stricter and safer interpretation.
+     *
      * @param stdClass $resobj the record being grouped, including the joined 'allowmultiple' column.
      * @param array $otherfields table's field names that refer to the other members of the compound index.
      * @return string the grouping key for this record.
      */
     protected function build_group_key(stdClass $resobj, array $otherfields): string {
-        if ((int) $resobj->allowmultiple) {
+        if ((int) ($resobj->allowmultiple ?? 0)) {
             return parent::build_group_key($resobj, $otherfields);
         }
 

--- a/classes/local/merger/choice_answers_table_merger.php
+++ b/classes/local/merger/choice_answers_table_merger.php
@@ -55,7 +55,7 @@ use stdClass;
  */
 class choice_answers_table_merger extends generic_table_merger {
     /**
-     * Return empty array. It has no other tables rather than 'choice_answers' to process.
+     * Return empty array. It has no other tables other than 'choice_answers' to process.
      *
      * The JOIN with {choice} added by self::build_sql_query() is read-only lookup data,
      * not a table this merger updates, so there is nothing else to skip here.

--- a/classes/local/merger/choice_answers_table_merger.php
+++ b/classes/local/merger/choice_answers_table_merger.php
@@ -1,0 +1,90 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Merges choice_answers records, accounting for mod_choice's per-instance
+ * 'allowmultiple' setting.
+ *
+ * @package   tool_mergeusers
+ * @author    Jordi Pujol Ahulló <jordi.pujol@urv.cat>
+ * @copyright 2026 onwards to Universitat Rovira i Virgili (https://www.urv.cat)
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_mergeusers\local\merger;
+
+use stdClass;
+
+/**
+ * Merges choice_answers records, accounting for mod_choice's per-instance
+ * 'allowmultiple' setting.
+ *
+ * Whether a single user can legitimately hold more than one choice_answers
+ * row for the same choiceid depends on that choice's own 'allowmultiple'
+ * column, on the {choice} table, not on choice_answers itself. When
+ * allowmultiple is off, a user may have at most one row per choiceid,
+ * regardless of optionid (mod/choice/lib.php's choice_user_outline() reads
+ * it with a plain, singular get_record(), which - with more than one
+ * matching row - silently returns only the first one and logs a
+ * debugging() notice, rather than reporting the user's real answer). When
+ * allowmultiple is on, a user may legitimately hold several rows per
+ * choiceid, one per optionid selected, and those must not be collapsed
+ * into each other.
+ *
+ * A single static 'otherfields' list cannot express both cases at once, so
+ * this table_merger groups records by choiceid alone when allowmultiple is
+ * off, and by (choiceid, optionid) when allowmultiple is on.
+ *
+ * @package   tool_mergeusers
+ * @author    Jordi Pujol Ahulló <jordi.pujol@urv.cat>
+ * @copyright 2026 onwards to Universitat Rovira i Virgili (https://www.urv.cat)
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class choice_answers_table_merger extends generic_table_merger {
+    /**
+     * Generates an SQL query that also fetches the owning choice's 'allowmultiple' value,
+     * needed by self::build_group_key() to decide the real uniqueness key per record.
+     *
+     * @param array $data Array containing the table name, `fromid`, and `toid` for the merging operation.
+     * @param string $userfield The field name in the table that refers to the user ID.
+     * @param string $otherfieldsstr A string representing the other fields in the compound index, separated by commas.
+     * @return array Array with the form [$sql, $params] to be used.
+     */
+    protected function build_sql_query(array $data, string $userfield, string $otherfieldsstr): array {
+        $sql = 'SELECT ca.id, ca.' . $userfield . ', ' . $otherfieldsstr . ', c.allowmultiple' .
+            ' FROM {' . $data['tableName'] . '} ca' .
+            ' JOIN {choice} c ON c.id = ca.choiceid' .
+            ' WHERE ca.' . $userfield . ' IN ( ?, ?)';
+
+        return [$sql, [$data['fromid'], $data['toid']]];
+    }
+
+    /**
+     * Builds the grouping key for a choice_answers record: choiceid alone when the owning
+     * choice does not allow multiple answers per user, or (choiceid, optionid) when it does.
+     *
+     * @param stdClass $resobj the record being grouped, including the joined 'allowmultiple' column.
+     * @param array $otherfields table's field names that refer to the other members of the compound index.
+     * @return string the grouping key for this record.
+     */
+    protected function build_group_key(stdClass $resobj, array $otherfields): string {
+        if ((int) $resobj->allowmultiple) {
+            return parent::build_group_key($resobj, $otherfields);
+        }
+
+        return (string) $resobj->choiceid;
+    }
+}

--- a/classes/local/merger/choice_answers_table_merger.php
+++ b/classes/local/merger/choice_answers_table_merger.php
@@ -55,6 +55,18 @@ use stdClass;
  */
 class choice_answers_table_merger extends generic_table_merger {
     /**
+     * Return empty array. It has no other tables rather than 'choice_answers' to process.
+     *
+     * The JOIN with {choice} added by self::build_sql_query() is read-only lookup data,
+     * not a table this merger updates, so there is nothing else to skip here.
+     *
+     * @return array Empty list.
+     */
+    public function get_tables_to_skip(): array {
+        return [];
+    }
+
+    /**
      * Generates an SQL query that also fetches the owning choice's 'allowmultiple' value,
      * needed by self::build_group_key() to decide the real uniqueness key per record.
      *

--- a/classes/local/merger/generic_table_merger.php
+++ b/classes/local/merger/generic_table_merger.php
@@ -28,6 +28,7 @@ namespace tool_mergeusers\local\merger;
 use coding_exception;
 use dml_exception;
 use Exception;
+use stdClass;
 
 /**
  * Generic implementation of a table_merger.
@@ -143,11 +144,7 @@ class generic_table_merger implements table_merger {
         $itemarr = [];
         $idstoremove = [];
         foreach ($result as $id => $resobj) {
-            $keyfromother = [];
-            foreach ($otherfields as $of) {
-                $keyfromother[] = $resobj->$of;
-            }
-            $keyfromotherstr = implode('-', $keyfromother);
+            $keyfromotherstr = $this->build_group_key($resobj, $otherfields);
             $itemarr[$keyfromotherstr][$resobj->$userfield] = $id;
         }
 
@@ -166,6 +163,27 @@ class generic_table_merger implements table_merger {
 
         unset($idstoremove);
         unset($sql);
+    }
+
+    /**
+     * Builds the grouping key used to detect compound-index conflicts for a given record.
+     *
+     * The default implementation simply concatenates the values of $otherfields, so that
+     * records sharing the same combination of those column values are grouped together.
+     * This method can be overridden by subclasses whose real uniqueness constraint depends
+     * on data outside the fixed $otherfields list (e.g. a flag on a related table that
+     * changes which columns actually make a record unique for a given user).
+     *
+     * @param stdClass $resobj the record being grouped, as returned by self::build_sql_query().
+     * @param array $otherfields table's field names that refer to the other members of the compound index.
+     * @return string the grouping key for this record.
+     */
+    protected function build_group_key(stdClass $resobj, array $otherfields): string {
+        $keyfromother = [];
+        foreach ($otherfields as $of) {
+            $keyfromother[] = $resobj->$of;
+        }
+        return implode('-', $keyfromother);
     }
 
     /**

--- a/classes/local/picture_merger.php
+++ b/classes/local/picture_merger.php
@@ -155,8 +155,8 @@ final class picture_merger {
      * because the user is suspended (as opposed to genuinely having none, or matching this plugin's
      * own recorded placeholder value), so the merge's persisted log distinguishes this case too.
      *
-     * @param int $userid
-     * @param array{trusted: bool, suspended: bool} $status
+     * @param int $userid id of the user whose picture is being evaluated.
+     * @param array $status shape: ['trusted' => bool, 'suspended' => bool], see self::picture_status().
      * @param array $actions list of log lines to append to, by reference.
      * @return void
      */

--- a/classes/local/picture_merger.php
+++ b/classes/local/picture_merger.php
@@ -155,6 +155,11 @@ final class picture_merger {
      * because the user is suspended (as opposed to genuinely having none, or matching this plugin's
      * own recorded placeholder value), so the merge's persisted log distinguishes this case too.
      *
+     * Deliberately not using an array{...} shape annotation for $status below (unlike
+     * self::picture_status()'s return type): on a parameter tag, moodle-plugin-ci's phpdoc
+     * checker misreports it as an incomplete parameter list and fails CI - verified by
+     * reproducing it locally with that exact syntax.
+     *
      * @param int $userid id of the user whose picture is being evaluated.
      * @param array $status shape: ['trusted' => bool, 'suspended' => bool], see self::picture_status().
      * @param array $actions list of log lines to append to, by reference.

--- a/tests/choice_answers_table_merger_test.php
+++ b/tests/choice_answers_table_merger_test.php
@@ -16,6 +16,8 @@
 
 namespace tool_mergeusers;
 
+use tool_mergeusers\local\jsonizer;
+use tool_mergeusers\local\merger\generic_table_merger;
 use tool_mergeusers\local\user_merger;
 
 /**
@@ -54,12 +56,82 @@ final class choice_answers_table_merger_test extends \advanced_testcase {
      * choice_user_outline() reports the merged user's real answer instead of silently
      * returning an arbitrary one of the duplicates.
      *
+     * @see self::test_without_specialized_merger_allowmultiple_off_leaves_inconsistency() for
+     * the same scenario left unresolved when choice_answers_table_merger is not used.
+     *
      * @group tool_mergeusers
      * @group tool_mergeusers_choice_answers
      * @covers \tool_mergeusers\local\merger\choice_answers_table_merger::build_group_key
      * @covers \tool_mergeusers\local\merger\choice_answers_table_merger::build_sql_query
      */
     public function test_single_select_choice_merges_to_one_answer(): void {
+        global $DB;
+
+        $choice = $this->create_single_select_conflicting_scenario();
+
+        $mut = new user_merger();
+        $mut->merge($this->userkeep->id, $this->userremove->id);
+
+        $answers = $DB->get_records('choice_answers', ['choiceid' => $choice->id, 'userid' => $this->userkeep->id]);
+        $this->assertCount(1, $answers);
+        $this->assertFalse(
+            $DB->record_exists('choice_answers', ['choiceid' => $choice->id, 'userid' => $this->userremove->id])
+        );
+
+        $cm = get_coursemodule_from_id('choice', $choice->cmid);
+        $outline = choice_user_outline($this->course, $this->userkeep, $cm, $choice);
+        $this->assertNotNull($outline);
+    }
+
+    /**
+     * Demonstrates why choice_answers_table_merger is needed at all: with the plain
+     * generic_table_merger (grouping strictly by the static (choiceid, optionid)
+     * otherfields), two users who picked different options on a single-select choice are
+     * never recognised as conflicting, so both answers survive the merge. get_record()'s
+     * default strictness does not throw on this - it silently returns an arbitrary one of
+     * the two rows (and logs a debugging() notice), so choice_user_outline() ends up
+     * reporting a wrong answer instead of the merged user's real one.
+     *
+     * @see self::test_single_select_choice_merges_to_one_answer() for the same scenario
+     * resolved correctly with the default configuration (choice_answers_table_merger active).
+     *
+     * @group tool_mergeusers
+     * @group tool_mergeusers_choice_answers
+     * @covers \tool_mergeusers\local\merger\choice_answers_table_merger
+     */
+    public function test_without_specialized_merger_allowmultiple_off_leaves_inconsistency(): void {
+        global $DB;
+
+        set_config(
+            'customdbsettings',
+            jsonizer::to_json(['tablemergers' => ['choice_answers' => generic_table_merger::class]]),
+            'tool_mergeusers'
+        );
+
+        $choice = $this->create_single_select_conflicting_scenario();
+
+        $mut = new user_merger();
+        $mut->merge($this->userkeep->id, $this->userremove->id);
+
+        $this->assertCount(
+            2,
+            $DB->get_records('choice_answers', ['choiceid' => $choice->id, 'userid' => $this->userkeep->id])
+        );
+
+        $cm = get_coursemodule_from_id('choice', $choice->cmid);
+        $outline = choice_user_outline($this->course, $this->userkeep, $cm, $choice);
+        $this->assertNotNull($outline);
+        $this->assertDebuggingCalled('Error: mdb->get_record() found more than one record!');
+    }
+
+    /**
+     * Creates a single-select choice (allowmultiple=0) with two conflicting answers: the
+     * user to remove picks one option, the user to keep picks a different one - a scenario
+     * that should never exist for a single user after a correct merge.
+     *
+     * @return \stdClass the created choice instance.
+     */
+    private function create_single_select_conflicting_scenario(): \stdClass {
         global $DB;
 
         $generator = $this->getDataGenerator()->get_plugin_generator('mod_choice');
@@ -81,18 +153,7 @@ final class choice_answers_table_merger_test extends \advanced_testcase {
             'userid' => $this->userkeep->id,
         ]);
 
-        $mut = new user_merger();
-        $mut->merge($this->userkeep->id, $this->userremove->id);
-
-        $answers = $DB->get_records('choice_answers', ['choiceid' => $choice->id, 'userid' => $this->userkeep->id]);
-        $this->assertCount(1, $answers);
-        $this->assertFalse(
-            $DB->record_exists('choice_answers', ['choiceid' => $choice->id, 'userid' => $this->userremove->id])
-        );
-
-        $cm = get_coursemodule_from_id('choice', $choice->cmid);
-        $outline = choice_user_outline($this->course, $this->userkeep, $cm, $choice);
-        $this->assertNotNull($outline);
+        return $choice;
     }
 
     /**

--- a/tests/choice_answers_table_merger_test.php
+++ b/tests/choice_answers_table_merger_test.php
@@ -140,5 +140,10 @@ final class choice_answers_table_merger_test extends \advanced_testcase {
         $expected = [(int) $options[0]->id, (int) $options[1]->id];
         sort($expected);
         $this->assertEquals($expected, $optionids);
+
+        $this->assertCount(
+            0,
+            $DB->get_records('choice_answers', ['choiceid' => $choice->id, 'userid' => $this->userremove->id])
+        );
     }
 }

--- a/tests/choice_answers_table_merger_test.php
+++ b/tests/choice_answers_table_merger_test.php
@@ -1,0 +1,144 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_mergeusers;
+
+use tool_mergeusers\local\user_merger;
+
+/**
+ * Tests for choice_answers_table_merger class.
+ *
+ * @package    tool_mergeusers
+ * @author     Jordi Pujol Ahulló <jordi.pujol@urv.cat>
+ * @copyright  2026 onwards to Universitat Rovira i Virgili (https://www.urv.cat)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class choice_answers_table_merger_test extends \advanced_testcase {
+    /** @var \stdClass */
+    private $course;
+    /** @var \stdClass */
+    private $userkeep;
+    /** @var \stdClass */
+    private $userremove;
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest();
+
+        global $CFG;
+        require_once($CFG->dirroot . '/mod/choice/lib.php');
+
+        $this->course = $this->getDataGenerator()->create_course();
+        $this->userkeep = $this->getDataGenerator()->create_user(['firstname' => 'Kept']);
+        $this->userremove = $this->getDataGenerator()->create_user(['firstname' => 'Removed']);
+        $this->getDataGenerator()->enrol_user($this->userkeep->id, $this->course->id, 'student');
+        $this->getDataGenerator()->enrol_user($this->userremove->id, $this->course->id, 'student');
+    }
+
+    /**
+     * When a choice does not allow multiple answers, two users who each picked a different
+     * option for the same choice must be merged down to a single answer, so that
+     * choice_user_outline() reports the merged user's real answer instead of silently
+     * returning an arbitrary one of the duplicates.
+     *
+     * @group tool_mergeusers
+     * @group tool_mergeusers_choice_answers
+     * @covers \tool_mergeusers\local\merger\choice_answers_table_merger::build_group_key
+     * @covers \tool_mergeusers\local\merger\choice_answers_table_merger::build_sql_query
+     */
+    public function test_single_select_choice_merges_to_one_answer(): void {
+        global $DB;
+
+        $generator = $this->getDataGenerator()->get_plugin_generator('mod_choice');
+        $choice = $generator->create_instance([
+            'course' => $this->course->id,
+            'allowmultiple' => 0,
+            'option' => ['Tea', 'Coffee'],
+        ]);
+        $options = array_values($DB->get_records('choice_options', ['choiceid' => $choice->id], 'id'));
+
+        $generator->create_response([
+            'choiceid' => $choice->id,
+            'responses' => $options[0]->id,
+            'userid' => $this->userremove->id,
+        ]);
+        $generator->create_response([
+            'choiceid' => $choice->id,
+            'responses' => $options[1]->id,
+            'userid' => $this->userkeep->id,
+        ]);
+
+        $mut = new user_merger();
+        $mut->merge($this->userkeep->id, $this->userremove->id);
+
+        $answers = $DB->get_records('choice_answers', ['choiceid' => $choice->id, 'userid' => $this->userkeep->id]);
+        $this->assertCount(1, $answers);
+        $this->assertFalse(
+            $DB->record_exists('choice_answers', ['choiceid' => $choice->id, 'userid' => $this->userremove->id])
+        );
+
+        $cm = get_coursemodule_from_id('choice', $choice->cmid);
+        $outline = choice_user_outline($this->course, $this->userkeep, $cm, $choice);
+        $this->assertNotNull($outline);
+    }
+
+    /**
+     * When a choice allows multiple answers, a user's own distinct selections must all
+     * survive the merge, while any selection colliding with the other user's own choice
+     * of the very same option must be deduplicated to a single row.
+     *
+     * @group tool_mergeusers
+     * @group tool_mergeusers_choice_answers
+     * @covers \tool_mergeusers\local\merger\choice_answers_table_merger::build_group_key
+     * @covers \tool_mergeusers\local\merger\choice_answers_table_merger::build_sql_query
+     */
+    public function test_multi_select_choice_keeps_distinct_selections_and_dedupes_conflicts(): void {
+        global $DB;
+
+        $generator = $this->getDataGenerator()->get_plugin_generator('mod_choice');
+        $choice = $generator->create_instance([
+            'course' => $this->course->id,
+            'allowmultiple' => 1,
+            'option' => ['Tea', 'Coffee', 'Juice'],
+        ]);
+        $options = array_values($DB->get_records('choice_options', ['choiceid' => $choice->id], 'id'));
+
+        // The user to remove has two legitimate selections of their own.
+        $generator->create_response([
+            'choiceid' => $choice->id,
+            'responses' => [$options[0]->id, $options[1]->id],
+            'userid' => $this->userremove->id,
+        ]);
+        // The user to keep selected the same first option as the user to remove: a real conflict.
+        $generator->create_response([
+            'choiceid' => $choice->id,
+            'responses' => $options[0]->id,
+            'userid' => $this->userkeep->id,
+        ]);
+
+        $mut = new user_merger();
+        $mut->merge($this->userkeep->id, $this->userremove->id);
+
+        $answers = $DB->get_records('choice_answers', ['choiceid' => $choice->id, 'userid' => $this->userkeep->id]);
+        $this->assertCount(2, $answers);
+
+        $optionids = array_values(array_map(fn($answer) => (int) $answer->optionid, $answers));
+        sort($optionids);
+        $expected = [(int) $options[0]->id, (int) $options[1]->id];
+        sort($expected);
+        $this->assertEquals($expected, $optionids);
+    }
+}

--- a/tests/choice_answers_table_merger_test.php
+++ b/tests/choice_answers_table_merger_test.php
@@ -142,18 +142,31 @@ final class choice_answers_table_merger_test extends \advanced_testcase {
         ]);
         $options = array_values($DB->get_records('choice_options', ['choiceid' => $choice->id], 'id'));
 
-        $generator->create_response([
-            'choiceid' => $choice->id,
-            'responses' => $options[0]->id,
-            'userid' => $this->userremove->id,
-        ]);
-        $generator->create_response([
-            'choiceid' => $choice->id,
-            'responses' => $options[1]->id,
-            'userid' => $this->userkeep->id,
-        ]);
+        $this->submit_choice_response($choice, $options[0]->id, $this->userremove->id);
+        $this->submit_choice_response($choice, $options[1]->id, $this->userkeep->id);
 
         return $choice;
+    }
+
+    /**
+     * Submits a choice response for the given user.
+     *
+     * mod_choice's own test generator only gained a create_response() method in Moodle 5.1
+     * (MDL-83179); this plugin still supports 4.5+, so this calls the underlying core
+     * function directly instead - the exact same call create_response() makes internally,
+     * and stable across every supported version.
+     *
+     * @param \stdClass $choice the choice instance, as returned by the generator's create_instance().
+     * @param int|array $responses a single optionid, or an array of optionids for allowmultiple choices.
+     * @param int $userid the user submitting the response.
+     * @return void
+     */
+    private function submit_choice_response(\stdClass $choice, int|array $responses, int $userid): void {
+        global $DB;
+
+        [$course, $cm] = get_course_and_cm_from_instance($choice->id, 'choice');
+        $choicerecord = $DB->get_record('choice', ['id' => $choice->id], '*', MUST_EXIST);
+        choice_user_submit_response($responses, $choicerecord, $userid, $course, $cm);
     }
 
     /**
@@ -178,17 +191,9 @@ final class choice_answers_table_merger_test extends \advanced_testcase {
         $options = array_values($DB->get_records('choice_options', ['choiceid' => $choice->id], 'id'));
 
         // The user to remove has two legitimate selections of their own.
-        $generator->create_response([
-            'choiceid' => $choice->id,
-            'responses' => [$options[0]->id, $options[1]->id],
-            'userid' => $this->userremove->id,
-        ]);
+        $this->submit_choice_response($choice, [$options[0]->id, $options[1]->id], $this->userremove->id);
         // The user to keep selected the same first option as the user to remove: a real conflict.
-        $generator->create_response([
-            'choiceid' => $choice->id,
-            'responses' => $options[0]->id,
-            'userid' => $this->userkeep->id,
-        ]);
+        $this->submit_choice_response($choice, $options[0]->id, $this->userkeep->id);
 
         $mut = new user_merger();
         $mut->merge($this->userkeep->id, $this->userremove->id);

--- a/tests/choice_answers_table_merger_test.php
+++ b/tests/choice_answers_table_merger_test.php
@@ -121,7 +121,10 @@ final class choice_answers_table_merger_test extends \advanced_testcase {
         $cm = get_coursemodule_from_id('choice', $choice->cmid);
         $outline = choice_user_outline($this->course, $this->userkeep, $cm, $choice);
         $this->assertNotNull($outline);
-        $this->assertDebuggingCalled('Error: mdb->get_record() found more than one record!');
+        // Not asserting the exact debugging() message text: it is not guaranteed to stay
+        // stable across Moodle versions or DB drivers, and the row count assertion above
+        // already verifies the actual inconsistency this test is about.
+        $this->assertDebuggingCalled();
     }
 
     /**

--- a/tests/survey_answers_compound_index_test.php
+++ b/tests/survey_answers_compound_index_test.php
@@ -148,5 +148,7 @@ final class survey_answers_compound_index_test extends \advanced_testcase {
 
         $answers = $DB->get_records('survey_answers', ['survey' => $surveyid, 'userid' => $userkeep->id]);
         $this->assertCount(2, $answers);
+
+        $this->assertCount(0, $DB->get_records('survey_answers', ['survey' => $surveyid, 'userid' => $userremove->id]));
     }
 }

--- a/tests/survey_answers_compound_index_test.php
+++ b/tests/survey_answers_compound_index_test.php
@@ -1,0 +1,152 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_mergeusers;
+
+use tool_mergeusers\local\user_merger;
+
+/**
+ * Tests for the survey_answers compound index configuration.
+ *
+ * mod_survey was removed from Moodle core after 4.5, but this plugin still declares support
+ * for 4.5. On a Moodle version where mod_survey (and its survey_answers table) is not
+ * installed, these tests are skipped rather than failed.
+ *
+ * @package    tool_mergeusers
+ * @author     Jordi Pujol Ahulló <jordi.pujol@urv.cat>
+ * @copyright  2026 onwards to Universitat Rovira i Virgili (https://www.urv.cat)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class survey_answers_compound_index_test extends \advanced_testcase {
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest();
+
+        global $DB;
+        $dbman = $DB->get_manager();
+        if (!$dbman->table_exists('survey') || !$dbman->table_exists('survey_answers')) {
+            $this->markTestSkipped('mod_survey is not installed on this Moodle version.');
+        }
+    }
+
+    /**
+     * Two users answering the same survey question must be merged down to a single answer,
+     * instead of leaving the merged user with two answers to the same question, which would
+     * silently double-count in survey results reports.
+     *
+     * @group tool_mergeusers
+     * @group tool_mergeusers_survey_answers
+     * @covers \tool_mergeusers\local\merger\generic_table_merger::merge_compound_index
+     */
+    public function test_merge_deduplicates_same_question_answer(): void {
+        global $DB;
+
+        $course = $this->getDataGenerator()->create_course();
+        $userkeep = $this->getDataGenerator()->create_user(['firstname' => 'Kept']);
+        $userremove = $this->getDataGenerator()->create_user(['firstname' => 'Removed']);
+
+        $surveyid = $DB->insert_record('survey', (object) [
+            'course' => $course->id,
+            'template' => 0,
+            'days' => 0,
+            'timecreated' => time(),
+            'timemodified' => time(),
+            'name' => 'Test survey',
+            'intro' => '',
+            'introformat' => FORMAT_MOODLE,
+            'questions' => '1',
+            'completionsubmit' => 0,
+        ]);
+
+        $DB->insert_record('survey_answers', (object) [
+            'userid' => $userremove->id,
+            'survey' => $surveyid,
+            'question' => 1,
+            'time' => time(),
+            'answer1' => 'Answer from removed user',
+            'answer2' => '',
+        ]);
+        $DB->insert_record('survey_answers', (object) [
+            'userid' => $userkeep->id,
+            'survey' => $surveyid,
+            'question' => 1,
+            'time' => time(),
+            'answer1' => 'Answer from kept user',
+            'answer2' => '',
+        ]);
+
+        $mut = new user_merger();
+        $mut->merge($userkeep->id, $userremove->id);
+
+        $answers = $DB->get_records('survey_answers', ['survey' => $surveyid, 'userid' => $userkeep->id]);
+        $this->assertCount(1, $answers);
+        $this->assertFalse(
+            $DB->record_exists('survey_answers', ['survey' => $surveyid, 'userid' => $userremove->id])
+        );
+    }
+
+    /**
+     * A user's own legitimate answers to different questions of the same survey must all
+     * survive the merge unaffected.
+     *
+     * @group tool_mergeusers
+     * @group tool_mergeusers_survey_answers
+     * @covers \tool_mergeusers\local\merger\generic_table_merger::merge_compound_index
+     */
+    public function test_merge_keeps_answers_to_different_questions(): void {
+        global $DB;
+
+        $course = $this->getDataGenerator()->create_course();
+        $userkeep = $this->getDataGenerator()->create_user(['firstname' => 'Kept']);
+        $userremove = $this->getDataGenerator()->create_user(['firstname' => 'Removed']);
+
+        $surveyid = $DB->insert_record('survey', (object) [
+            'course' => $course->id,
+            'template' => 0,
+            'days' => 0,
+            'timecreated' => time(),
+            'timemodified' => time(),
+            'name' => 'Test survey',
+            'intro' => '',
+            'introformat' => FORMAT_MOODLE,
+            'questions' => '1,2',
+            'completionsubmit' => 0,
+        ]);
+
+        $DB->insert_record('survey_answers', (object) [
+            'userid' => $userremove->id,
+            'survey' => $surveyid,
+            'question' => 1,
+            'time' => time(),
+            'answer1' => 'Answer to question 1',
+            'answer2' => '',
+        ]);
+        $DB->insert_record('survey_answers', (object) [
+            'userid' => $userkeep->id,
+            'survey' => $surveyid,
+            'question' => 2,
+            'time' => time(),
+            'answer1' => 'Answer to question 2',
+            'answer2' => '',
+        ]);
+
+        $mut = new user_merger();
+        $mut->merge($userkeep->id, $userremove->id);
+
+        $answers = $DB->get_records('survey_answers', ['survey' => $surveyid, 'userid' => $userkeep->id]);
+        $this->assertCount(2, $answers);
+    }
+}

--- a/version.php
+++ b/version.php
@@ -30,8 +30,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2026081300;
-$plugin->release = '(2026081300: Focus on stability and extensibility)';
+$plugin->version = 2026081301;
+$plugin->release = '(2026081301: Focus on stability and extensibility)';
 $plugin->requires = 2024100700; // Moodle 4.5+, https://moodledev.io/general/releases#moodle-45-lts.
 $plugin->component = 'tool_mergeusers';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Supersedes #431, closed unintentionally when the source branch was renamed via the GitHub API (395-lesson-choice-survey-compound-indexes -> 395-choice-survey-compound-indexes, to drop a misleading "lesson" reference: lesson_attempts was evaluated for #395 but intentionally left out, see CHANGES.md).

Addresses #395: adds choice_answers (via a new choice_answers_table_merger, resolving conflicts per each choice's own allowmultiple setting) and survey_answers as compound indexes. lesson_attempts was evaluated too but left out - no crash or real DB constraint, only a cosmetic duplicate "try" number in lesson_report.php; a lossless fix would need a dedicated renumbering table_merger akin to quiz_attempts_table_merger, warranting its own future issue.

Thanks to @charbusch for raising the issue.